### PR TITLE
fix(packer): swap gnupg2-minimal for gnupg2 in AMI build

### DIFF
--- a/infra/packer/scripts/01-system-base.sh
+++ b/infra/packer/scripts/01-system-base.sh
@@ -13,12 +13,16 @@ sudo dnf install -y libicu lttng-ust openssl-libs krb5-libs zlib
 # Swap it out so we get full curl (needed by many GitHub Actions).
 sudo dnf swap -y curl-minimal curl --allowerasing
 
+# AL2023 also ships gnupg2-minimal which conflicts with the full gnupg2 package.
+# Swap it out so we get full gnupg2 (needed for key/signature workflows).
+sudo dnf swap -y gnupg2-minimal gnupg2 --allowerasing
+
 # Core utilities
 sudo dnf install -y \
   git make tar gzip unzip zip bzip2 xz zstd lz4 \
   wget rsync tree findutils which diffutils patch \
   procps-ng sudo shadow-utils \
-  openssl gnupg2 openssh-clients
+  openssl openssh-clients
 
 # Build tools (gcc, g++, autoconf, automake, etc.)
 echo "=== jit-runners: installing development tools ==="


### PR DESCRIPTION
## Summary
- AMI build (`ami-build.yml`) was failing in the `01-system-base.sh` provisioner because AL2023 ships `gnupg2-minimal` (which provides `gnupg2`), so `dnf install gnupg2` errored with a package conflict.
- Fix mirrors the existing `curl-minimal -> curl` swap a few lines above: explicit `dnf swap -y gnupg2-minimal gnupg2 --allowerasing`, then drop `gnupg2` from the bulk install list.
- Surfaced by the v0.3.0 tag push (run [25215391330](https://github.com/devopsfactory-io/jit-runners/actions/runs/25215391330)).

## Failure log (excerpt)
```
==> amazon-ebs.jit-runner: Error:
==> amazon-ebs.jit-runner:  Problem: problem with installed package gnupg2-minimal-2.3.7-1.amzn2023.0.8.x86_64
==> amazon-ebs.jit-runner:  - package gnupg2-minimal-2.3.7-1.amzn2023.0.8.x86_64 from @System conflicts
                              with gnupg2 provided by gnupg2-2.3.7-1.amzn2023.0.8.x86_64 from amazonlinux
==> amazon-ebs.jit-runner:  (try to add '--allowerasing' to command line ...)
```

## Test plan
- [ ] PR triggers `ami-build.yml` (path filter `infra/packer/**`) and the Packer build reaches `01-system-base.sh` past the `gnupg2-minimal -> gnupg2` swap.
- [ ] PR-mode build succeeds with the `jit-runner-pr` prefix and the AMI is auto-cleaned up after the run.
- [ ] No regressions in the `curl-minimal -> curl` swap or the Core utilities install.