### PR TITLE
feat(lifecycle): add lifecycle tracking, deregister, and re-enqueue (closes #47)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,6 +38,17 @@ builds:
     goarch:
       - amd64
 
+  - id: lifecycle
+    dir: lambda
+    main: ./cmd/lifecycle
+    binary: bootstrap
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+    goarch:
+      - amd64
+
 archives:
   - id: webhook-zip
     ids:
@@ -66,6 +77,16 @@ archives:
       - zip
     name_template: >-
       scaledown-{{ .Os }}-{{ .Arch }}
+    strip_binary_directory: true
+    wrap_in_directory: false
+
+  - id: lifecycle-zip
+    ids:
+      - lifecycle
+    formats:
+      - zip
+    name_template: >-
+      lifecycle-{{ .Os }}-{{ .Arch }}
     strip_binary_directory: true
     wrap_in_directory: false
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,8 +5,8 @@ This document captures the manual procedure for releasing a new version of
 Lambda code. It mirrors the steps used for the v0.3.0 release.
 
 > **Scope:** stack `jit-runners` in account `767000629676`, region `us-east-2`,
-> bucket `jit-runners-lambda-s3`, three functions
-> (`jit-runners-{webhook,scaleup,scaledown}`).
+> bucket `jit-runners-lambda-s3`, four functions
+> (`jit-runners-{webhook,scaleup,scaledown,lifecycle}`).
 
 > **Out of scope:** Terraform deployment (see `docs/getting-started-terraform.md`)
 > and the AMI build (see `infra/packer/`).
@@ -28,7 +28,7 @@ aws cloudformation describe-stacks \
   --stack-name jit-runners --region us-east-2 \
   --query 'Stacks[0].StackStatus'           # must be UPDATE_COMPLETE / CREATE_COMPLETE
 
-for fn in jit-runners-webhook jit-runners-scaleup jit-runners-scaledown; do
+for fn in jit-runners-webhook jit-runners-scaleup jit-runners-scaledown jit-runners-lifecycle; do
   aws lambda get-function --function-name "$fn" --region us-east-2 \
     --query 'Configuration.CodeSha256' --output text
 done
@@ -59,12 +59,13 @@ cd /tmp/jit-runners-vX.Y.Z
 mv webhook-linux-amd64.zip   webhook.zip
 mv scaleup-linux-amd64.zip   scaleup.zip
 mv scaledown-linux-amd64.zip scaledown.zip
+mv lifecycle-linux-amd64.zip lifecycle.zip
 ```
 
 ## 4. Upload to S3
 
 ```bash
-for f in webhook scaleup scaledown; do
+for f in webhook scaleup scaledown lifecycle; do
   aws s3 cp "/tmp/jit-runners-vX.Y.Z/${f}.zip" \
     "s3://jit-runners-lambda-s3/vX.Y.Z/${f}.zip"
 done
@@ -81,7 +82,10 @@ aws cloudformation update-stack \
     ParameterKey=WebhookLambdaS3Key,ParameterValue=vX.Y.Z/webhook.zip \
     ParameterKey=ScaleUpLambdaS3Key,ParameterValue=vX.Y.Z/scaleup.zip \
     ParameterKey=ScaleDownLambdaS3Key,ParameterValue=vX.Y.Z/scaledown.zip \
+    ParameterKey=LifecycleLambdaS3Key,ParameterValue=vX.Y.Z/lifecycle.zip \
+    ParameterKey=MaxReEnqueueAttempts,ParameterValue=3 \
     ParameterKey=GitHubAppId,UsePreviousValue=true \
+    ParameterKey=GitHubInstallationId,UsePreviousValue=true \
     ParameterKey=LambdaS3Bucket,UsePreviousValue=true \
     ParameterKey=WebhookSecretArn,UsePreviousValue=true \
     ParameterKey=PrivateKeySecretArn,UsePreviousValue=true \
@@ -105,7 +109,7 @@ named-IAM resources.
 Each Lambda's `CodeSha256` must differ from the pre-flight capture:
 
 ```bash
-for fn in jit-runners-webhook jit-runners-scaleup jit-runners-scaledown; do
+for fn in jit-runners-webhook jit-runners-scaleup jit-runners-scaledown jit-runners-lifecycle; do
   aws lambda get-function --function-name "$fn" --region us-east-2 \
     --query 'Configuration.CodeSha256' --output text
 done
@@ -130,7 +134,10 @@ aws cloudformation update-stack \
     ParameterKey=WebhookLambdaS3Key,ParameterValue=vPREV/webhook.zip \
     ParameterKey=ScaleUpLambdaS3Key,ParameterValue=vPREV/scaleup.zip \
     ParameterKey=ScaleDownLambdaS3Key,ParameterValue=vPREV/scaledown.zip \
+    ParameterKey=LifecycleLambdaS3Key,ParameterValue=vPREV/lifecycle.zip \
+    ParameterKey=MaxReEnqueueAttempts,UsePreviousValue=true \
     ParameterKey=GitHubAppId,UsePreviousValue=true \
+    ParameterKey=GitHubInstallationId,UsePreviousValue=true \
     ParameterKey=LambdaS3Bucket,UsePreviousValue=true \
     ParameterKey=WebhookSecretArn,UsePreviousValue=true \
     ParameterKey=PrivateKeySecretArn,UsePreviousValue=true \
@@ -157,3 +164,7 @@ The previous-version objects must still exist in S3 for rollback to work — do
 - The AMI build pipeline (`ami-build.yml`) auto-triggers on the same tag push
   but is independent — its success or failure does not affect the Lambda
   release. Track AMI build issues separately.
+- The lifecycle Lambda is new in v1.0.0-rc.1+. Releases prior to that do not
+  include `lifecycle.zip` and do not need the `LifecycleLambdaS3Key` or
+  `MaxReEnqueueAttempts` parameters. When rolling back to a pre-v1.0.0-rc.1
+  release, omit those two parameters from the `update-stack` command.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -466,3 +466,64 @@ gh workflow run ami-build.yml -f distribute=true
 - Update the AMI parameter promptly after each AMI build.
 - Use the `ami-build.yml` workflow which prints the new AMI ID in the job summary.
 - Consider automating the AMI parameter update as part of the build pipeline.
+
+---
+
+## 7. Re-enqueue and DLQ inspection
+
+### Symptom: jobs stuck in GitHub's queued state for > StaleThresholdMinutes
+
+The lifecycle handler updates DynamoDB on `in_progress` and `completed` events. If GitHub's
+scheduler hiccups and never delivers an `in_progress` event for a queued job,
+scaledown reaps the stale-pending record after `StaleThresholdMinutes` (default
+10), terminates the orphaned spot instance, deregisters the GitHub runner
+registration, and re-publishes the original `ScaleUpMessage` with
+`re_enqueue_attempts` incremented. After `MaxReEnqueueAttempts` (default 3), the
+message is left as terminal `failed` and an ERROR log line is emitted.
+
+### Inspection commands
+
+```bash
+# Lifecycle queue depth
+aws sqs get-queue-attributes \
+  --queue-url $(aws cloudformation describe-stack-resources \
+    --stack-name jit-runners --region us-east-2 \
+    --query 'StackResources[?LogicalResourceId==`LifecycleQueue`].PhysicalResourceId | [0]' \
+    --output text) \
+  --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible \
+  --region us-east-2
+
+# Lifecycle DLQ contents
+aws sqs receive-message \
+  --queue-url $(aws cloudformation describe-stack-resources \
+    --stack-name jit-runners --region us-east-2 \
+    --query 'StackResources[?LogicalResourceId==`LifecycleQueueDLQ`].PhysicalResourceId | [0]' \
+    --output text) \
+  --max-number-of-messages 10 \
+  --region us-east-2
+
+# Recent re-enqueue exhaustion log lines
+aws logs filter-log-events \
+  --log-group-name /aws/lambda/jit-runners-scaledown \
+  --filter-pattern '"re-enqueue exhausted"' \
+  --region us-east-2 --max-items 20
+```
+
+### Manual reset procedure
+
+If a job is in DynamoDB with `Status=failed` after re-enqueue exhaustion AND the
+GitHub job is still `queued`, you can manually re-enqueue by sending a fresh
+`ScaleUpMessage` with `re_enqueue_attempts` reset to 0:
+
+```bash
+aws sqs send-message \
+  --queue-url $(aws cloudformation describe-stack-resources \
+    --stack-name jit-runners --region us-east-2 \
+    --query 'StackResources[?LogicalResourceId==`ScaleUpQueue`].PhysicalResourceId | [0]' \
+    --output text) \
+  --message-body '{"job_id":<JOB_ID>,"repo":"owner/repo","labels":["self-hosted","large"],"re_enqueue_attempts":0}' \
+  --region us-east-2
+```
+
+The scaleup function's idempotency guard (`Status == StatusRunning` → skip)
+ensures this is safe even if the original runner did register.

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -6,6 +6,10 @@ Parameters:
     Type: String
     Description: GitHub App ID (numeric).
 
+  GitHubInstallationId:
+    Type: String
+    Description: GitHub App installation ID (numeric) used by lifecycle and scaledown for installation-token minting.
+
   LambdaS3Bucket:
     Type: String
     Description: S3 bucket containing the Lambda deployment packages.
@@ -21,6 +25,10 @@ Parameters:
   ScaleDownLambdaS3Key:
     Type: String
     Description: S3 key for the scale-down Lambda zip.
+
+  LifecycleLambdaS3Key:
+    Type: String
+    Description: S3 key for the lifecycle Lambda zip.
 
   WebhookSecretArn:
     Type: String
@@ -56,6 +64,13 @@ Parameters:
     Type: Number
     Default: 360
     Description: Maximum age in minutes before a running instance is force-terminated.
+
+  MaxReEnqueueAttempts:
+    Type: Number
+    Default: 3
+    MinValue: 1
+    MaxValue: 10
+    Description: Max re-enqueue attempts before a stuck pending job goes terminal.
 
 Resources:
   # --- DynamoDB ---
@@ -96,6 +111,22 @@ Resources:
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt ScaleUpDLQ.Arn
         maxReceiveCount: 3
+
+  LifecycleQueueDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-lifecycle-dlq"
+      MessageRetentionPeriod: 1209600
+
+  LifecycleQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-lifecycle"
+      VisibilityTimeout: 90
+      MessageRetentionPeriod: 86400
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt LifecycleQueueDLQ.Arn
+        maxReceiveCount: 5
 
   # --- EC2 Security Group ---
 
@@ -188,6 +219,9 @@ Resources:
                 Action: sqs:SendMessage
                 Resource: !GetAtt ScaleUpQueue.Arn
               - Effect: Allow
+                Action: sqs:SendMessage
+                Resource: !GetAtt LifecycleQueue.Arn
+              - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource:
                   - !Ref WebhookSecretArn
@@ -209,9 +243,11 @@ Resources:
       Environment:
         Variables:
           GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
           GITHUB_APP_WEBHOOK_SECRET_ARN: !Ref WebhookSecretArn
           GITHUB_APP_PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
           SQS_QUEUE_URL: !Ref ScaleUpQueue
+          LIFECYCLE_QUEUE_URL: !Ref LifecycleQueue
           DYNAMODB_TABLE_NAME: !Ref RunnersTable
 
   WebhookLogGroup:
@@ -320,6 +356,7 @@ Resources:
       Environment:
         Variables:
           GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
           GITHUB_APP_WEBHOOK_SECRET_ARN: !Ref WebhookSecretArn
           GITHUB_APP_PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
           SQS_QUEUE_URL: !Ref ScaleUpQueue
@@ -374,6 +411,9 @@ Resources:
                   - ec2:TerminateInstances
                 Resource: "*"
               - Effect: Allow
+                Action: sqs:SendMessage
+                Resource: !GetAtt ScaleUpQueue.Arn
+              - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource:
                   - !Ref WebhookSecretArn
@@ -395,18 +435,94 @@ Resources:
       Environment:
         Variables:
           GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
           GITHUB_APP_WEBHOOK_SECRET_ARN: !Ref WebhookSecretArn
           GITHUB_APP_PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
           SQS_QUEUE_URL: !Ref ScaleUpQueue
+          SCALEUP_QUEUE_URL: !Ref ScaleUpQueue
           DYNAMODB_TABLE_NAME: !Ref RunnersTable
           STALE_THRESHOLD_MINUTES: !Ref StaleThresholdMinutes
           MAX_RUNNER_AGE_MINUTES: !Ref MaxRunnerAgeMinutes
+          MAX_RE_ENQUEUE_ATTEMPTS: !Ref MaxReEnqueueAttempts
 
   ScaleDownLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-scaledown"
       RetentionInDays: 14
+
+  # --- Lifecycle Lambda ---
+
+  LifecycleFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-lifecycle-lambda"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: lifecycle-permissions
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:ChangeMessageVisibility
+                Resource: !GetAtt LifecycleQueue.Arn
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                  - dynamodb:UpdateItem
+                Resource: !GetAtt RunnersTable.Arn
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource: !Ref PrivateKeySecretArn
+
+  LifecycleFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-lifecycle"
+      Description: Consumes lifecycle events; updates DDB through pending/running/completed and deregisters runners.
+      Runtime: provided.al2023
+      Handler: bootstrap
+      Architectures: [x86_64]
+      Code:
+        S3Bucket: !Ref LambdaS3Bucket
+        S3Key: !Ref LifecycleLambdaS3Key
+      Timeout: 30
+      MemorySize: 128
+      Role: !GetAtt LifecycleFunctionRole.Arn
+      Environment:
+        Variables:
+          DYNAMODB_TABLE: !Ref RunnersTable
+          DYNAMODB_TABLE_NAME: !Ref RunnersTable
+          GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
+          PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
+          GITHUB_APP_PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
+
+  LifecycleLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-lifecycle"
+      RetentionInDays: 14
+
+  LifecycleFunctionEventSource:
+    Type: AWS::Lambda::EventSourceMapping
+    Properties:
+      EventSourceArn: !GetAtt LifecycleQueue.Arn
+      FunctionName: !Ref LifecycleFunction
+      BatchSize: 10
+      MaximumBatchingWindowInSeconds: 1
 
   # --- EventBridge Scheduler ---
 
@@ -459,6 +575,18 @@ Outputs:
   ScaleDownLambdaArn:
     Description: ARN of the scale-down Lambda function.
     Value: !GetAtt ScaleDownFunction.Arn
+
+  LifecycleFunctionArn:
+    Description: ARN of the lifecycle Lambda function.
+    Value: !GetAtt LifecycleFunction.Arn
+
+  LifecycleQueueUrl:
+    Description: SQS queue URL for lifecycle messages (workflow_job in_progress / completed).
+    Value: !Ref LifecycleQueue
+
+  LifecycleQueueDLQUrl:
+    Description: SQS DLQ URL for lifecycle messages.
+    Value: !Ref LifecycleQueueDLQ
 
   DynamoDBTableName:
     Description: DynamoDB table name for runner state.

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -15,11 +15,13 @@ resource "aws_lambda_function" "webhook" {
 
   environment {
     variables = {
-      GITHUB_APP_ID                    = var.github_app_id
-      GITHUB_APP_WEBHOOK_SECRET_ARN    = var.webhook_secret_arn
+      GITHUB_APP_ID                     = var.github_app_id
+      GITHUB_INSTALLATION_ID            = var.github_installation_id
+      GITHUB_APP_WEBHOOK_SECRET_ARN     = var.webhook_secret_arn
       GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.private_key_arn
-      SQS_QUEUE_URL                    = aws_sqs_queue.scaleup.url
-      DYNAMODB_TABLE_NAME              = aws_dynamodb_table.runners.name
+      SQS_QUEUE_URL                     = aws_sqs_queue.scaleup.url
+      LIFECYCLE_QUEUE_URL               = aws_sqs_queue.lifecycle.url
+      DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
     }
   }
 
@@ -50,16 +52,17 @@ resource "aws_lambda_function" "scaleup" {
 
   environment {
     variables = {
-      GITHUB_APP_ID                    = var.github_app_id
-      GITHUB_APP_WEBHOOK_SECRET_ARN    = var.webhook_secret_arn
+      GITHUB_APP_ID                     = var.github_app_id
+      GITHUB_INSTALLATION_ID            = var.github_installation_id
+      GITHUB_APP_WEBHOOK_SECRET_ARN     = var.webhook_secret_arn
       GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.private_key_arn
-      SQS_QUEUE_URL                    = aws_sqs_queue.scaleup.url
-      DYNAMODB_TABLE_NAME              = aws_dynamodb_table.runners.name
-      EC2_SUBNET_IDS                   = join(",", var.subnet_ids)
-      EC2_SECURITY_GROUP_ID            = aws_security_group.runner.id
-      EC2_IAM_INSTANCE_PROFILE         = aws_iam_instance_profile.runner.name
-      EC2_DEFAULT_AMI                  = var.default_ami
-      LABEL_MAPPINGS                   = var.label_mappings
+      SQS_QUEUE_URL                     = aws_sqs_queue.scaleup.url
+      DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
+      EC2_SUBNET_IDS                    = join(",", var.subnet_ids)
+      EC2_SECURITY_GROUP_ID             = aws_security_group.runner.id
+      EC2_IAM_INSTANCE_PROFILE          = aws_iam_instance_profile.runner.name
+      EC2_DEFAULT_AMI                   = var.default_ami
+      LABEL_MAPPINGS                    = var.label_mappings
     }
   }
 
@@ -96,13 +99,16 @@ resource "aws_lambda_function" "scaledown" {
 
   environment {
     variables = {
-      GITHUB_APP_ID                    = var.github_app_id
-      GITHUB_APP_WEBHOOK_SECRET_ARN    = var.webhook_secret_arn
+      GITHUB_APP_ID                     = var.github_app_id
+      GITHUB_INSTALLATION_ID            = var.github_installation_id
+      GITHUB_APP_WEBHOOK_SECRET_ARN     = var.webhook_secret_arn
       GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.private_key_arn
-      SQS_QUEUE_URL                    = aws_sqs_queue.scaleup.url
-      DYNAMODB_TABLE_NAME              = aws_dynamodb_table.runners.name
-      STALE_THRESHOLD_MINUTES          = tostring(var.stale_threshold_minutes)
-      MAX_RUNNER_AGE_MINUTES           = tostring(var.max_runner_age_minutes)
+      SQS_QUEUE_URL                     = aws_sqs_queue.scaleup.url
+      SCALEUP_QUEUE_URL                 = aws_sqs_queue.scaleup.url
+      DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
+      STALE_THRESHOLD_MINUTES           = tostring(var.stale_threshold_minutes)
+      MAX_RUNNER_AGE_MINUTES            = tostring(var.max_runner_age_minutes)
+      MAX_RE_ENQUEUE_ATTEMPTS           = tostring(var.max_re_enqueue_attempts)
     }
   }
 
@@ -153,6 +159,11 @@ resource "aws_iam_role_policy" "webhook_lambda" {
         Effect   = "Allow"
         Action   = ["sqs:SendMessage"]
         Resource = aws_sqs_queue.scaleup.arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.lifecycle.arn
       },
       {
         Effect = "Allow"
@@ -292,12 +303,125 @@ resource "aws_iam_role_policy" "scaledown_lambda" {
         Resource = "*"
       },
       {
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.scaleup.arn
+      },
+      {
         Effect = "Allow"
         Action = ["secretsmanager:GetSecretValue"]
         Resource = [
           var.webhook_secret_arn,
           var.private_key_arn,
         ]
+      },
+    ]
+  })
+}
+
+# --- Lifecycle Lambda ---
+
+resource "aws_lambda_function" "lifecycle" {
+  function_name = "${var.project_name}-lifecycle"
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["x86_64"]
+  memory_size   = 128
+  timeout       = 30
+
+  s3_bucket = var.webhook_lambda_s3_bucket
+  s3_key    = var.lifecycle_lambda_s3_key
+
+  role = aws_iam_role.lifecycle_lambda.arn
+
+  environment {
+    variables = {
+      GITHUB_APP_ID                     = var.github_app_id
+      GITHUB_INSTALLATION_ID            = var.github_installation_id
+      GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.private_key_arn
+      PRIVATE_KEY_SECRET_ARN            = var.private_key_arn
+      DYNAMODB_TABLE                    = aws_dynamodb_table.runners.name
+      DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-lifecycle"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "lifecycle" {
+  name              = "/aws/lambda/${var.project_name}-lifecycle"
+  retention_in_days = 14
+}
+
+resource "aws_lambda_event_source_mapping" "lifecycle" {
+  event_source_arn                   = aws_sqs_queue.lifecycle.arn
+  function_name                      = aws_lambda_function.lifecycle.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 1
+}
+
+# --- IAM: Lifecycle Lambda ---
+
+resource "aws_iam_role" "lifecycle_lambda" {
+  name = "${var.project_name}-lifecycle-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lifecycle_lambda_basic" {
+  role       = aws_iam_role.lifecycle_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "lifecycle_lambda" {
+  name = "${var.project_name}-lifecycle-lambda"
+  role = aws_iam_role.lifecycle_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.lifecycle.arn}:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "sqs:ChangeMessageVisibility",
+        ]
+        Resource = aws_sqs_queue.lifecycle.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+        ]
+        Resource = aws_dynamodb_table.runners.arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = [var.private_key_arn]
       },
     ]
   })

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -18,6 +18,21 @@ output "scaledown_lambda_arn" {
   value       = aws_lambda_function.scaledown.arn
 }
 
+output "lifecycle_function_arn" {
+  description = "ARN of the lifecycle Lambda function"
+  value       = aws_lambda_function.lifecycle.arn
+}
+
+output "lifecycle_queue_url" {
+  description = "SQS queue URL for lifecycle messages (workflow_job in_progress / completed)"
+  value       = aws_sqs_queue.lifecycle.url
+}
+
+output "lifecycle_queue_dlq_url" {
+  description = "SQS DLQ URL for lifecycle messages"
+  value       = aws_sqs_queue.lifecycle_dlq.url
+}
+
 output "dynamodb_table_name" {
   description = "DynamoDB table name for runner state"
   value       = aws_dynamodb_table.runners.name

--- a/infra/terraform/sqs.tf
+++ b/infra/terraform/sqs.tf
@@ -23,3 +23,27 @@ resource "aws_sqs_queue" "scaleup_dlq" {
     Name = "${var.project_name}-scaleup-dlq"
   }
 }
+
+resource "aws_sqs_queue" "lifecycle_dlq" {
+  name                      = "${var.project_name}-lifecycle-dlq"
+  message_retention_seconds = 1209600 # 14 days
+
+  tags = {
+    Name = "${var.project_name}-lifecycle-dlq"
+  }
+}
+
+resource "aws_sqs_queue" "lifecycle" {
+  name                       = "${var.project_name}-lifecycle"
+  visibility_timeout_seconds = 90
+  message_retention_seconds  = 86400 # 24 hours
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.lifecycle_dlq.arn
+    maxReceiveCount     = 5
+  })
+
+  tags = {
+    Name = "${var.project_name}-lifecycle"
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -17,6 +17,11 @@ variable "github_app_id" {
   type        = string
 }
 
+variable "github_installation_id" {
+  description = "GitHub App installation ID (numeric) used by lifecycle and scaledown for installation-token minting"
+  type        = string
+}
+
 variable "webhook_secret_arn" {
   description = "ARN of the Secrets Manager secret containing the GitHub webhook secret"
   type        = string
@@ -80,6 +85,11 @@ variable "scaledown_lambda_s3_key" {
   type        = string
 }
 
+variable "lifecycle_lambda_s3_key" {
+  description = "S3 key for the lifecycle Lambda zip"
+  type        = string
+}
+
 # --- Scale-down ---
 
 variable "stale_threshold_minutes" {
@@ -92,4 +102,10 @@ variable "max_runner_age_minutes" {
   description = "Maximum age in minutes before a running instance is force-terminated"
   type        = number
   default     = 360
+}
+
+variable "max_re_enqueue_attempts" {
+  description = "Max re-enqueue attempts before a stuck pending job goes terminal"
+  type        = number
+  default     = 3
 }

--- a/lambda/cmd/lifecycle/main.go
+++ b/lambda/cmd/lifecycle/main.go
@@ -1,34 +1,107 @@
+// Package main is the lifecycle Lambda entry point. It consumes lifecycle
+// SQS messages (workflow_job in_progress / completed) and applies the
+// state-machine transition + GitHub deregister side-effect.
+//
+// Construction mirrors cmd/scaledown and cmd/scaleup: load AWS config,
+// build a DynamoDB client + *runner.Store, wrap it in StateAdapter to
+// satisfy the cloud-agnostic state.RunnerStore the lifecycle handler
+// consumes, mint an installation token at startup for DeregisterRunner.
+//
+// We intentionally do not introduce a provider.Bundle abstraction here —
+// that lives in the parallel #45 cloud-abstraction line and would be a
+// merge hazard for #47.
 package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
+	"sync"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 
+	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
-	"github.com/devopsfactory-io/jit-runners/lambda/internal/provider"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
+)
+
+var (
+	cfgOnce sync.Once
+	appCfg  *appconfig.Config
+	cfgErr  error
 )
 
 func main() {
-	ctx := context.Background()
+	lambda.Start(handler)
+}
 
-	bundle, err := provider.New(ctx, os.Getenv("CLOUD_PROVIDER"))
+func handler(ctx context.Context, ev events.SQSEvent) error {
+	cfg, err := loadConfig(ctx)
 	if err != nil {
-		log.Fatalf("provider.New: %v", err)
+		return fmt.Errorf("load config: %w", err)
 	}
-	defer bundle.Close()
 
-	h := lifecycle.New(bundle.State, bundle.GitHub, log.Default())
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("load AWS config: %w", err)
+	}
 
-	lambda.Start(func(ctx context.Context, ev events.SQSEvent) error {
-		for _, rec := range ev.Records {
-			if err := h.HandleSQS(ctx, []byte(rec.Body)); err != nil {
-				return err
-			}
+	store := runner.NewStore(dynamodb.NewFromConfig(awsCfg), cfg.TableName)
+	adapter := runner.NewStateAdapter(store)
+
+	// Mint a real installation token when GITHUB_INSTALLATION_ID is set.
+	// Without it we fall back to a tokenless client and DeregisterRunner
+	// calls will 401, but the lifecycle DDB transitions still run — the
+	// handler logs and ignores deregister failures by design (DDB commit
+	// is the source of truth; deregister is best-effort cleanup).
+	ghClient, err := newGitHubClient(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("github client: %w", err)
+	}
+
+	h := lifecycle.New(adapter, ghClient, log.Default())
+
+	for _, rec := range ev.Records {
+		if err := h.HandleSQS(ctx, []byte(rec.Body)); err != nil {
+			return err
 		}
-		return nil
+	}
+	return nil
+}
+
+// newGitHubClient builds a *github.Client. When cfg.InstallationID is set
+// the client carries a fresh installation access token (mirrors the
+// scaleup flow). When unset we log a warning and return a tokenless
+// client — production should always set GITHUB_INSTALLATION_ID; the
+// fallback exists so a misconfigured Lambda cold-start does not crash and
+// continues to commit lifecycle transitions to DynamoDB.
+func newGitHubClient(ctx context.Context, cfg *appconfig.Config) (*github.Client, error) {
+	if cfg.InstallationID == 0 {
+		log.Printf("GITHUB_INSTALLATION_ID is unset: DeregisterRunner calls will 401; lifecycle DDB transitions will still run")
+		return github.NewClient(""), nil
+	}
+	token, err := github.InstallationToken(ctx, cfg.AppID, cfg.PrivateKey, cfg.InstallationID)
+	if err != nil {
+		return nil, fmt.Errorf("get installation token: %w", err)
+	}
+	return github.NewClient(token), nil
+}
+
+func loadConfig(ctx context.Context) (*appconfig.Config, error) {
+	cfgOnce.Do(func() {
+		appCfg, cfgErr = appconfig.Load(ctx)
 	})
+	return appCfg, cfgErr
+}
+
+func init() {
+	log.SetFlags(log.Lshortfile)
+	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
+		log.SetOutput(os.Stdout)
+	}
 }

--- a/lambda/cmd/lifecycle/main.go
+++ b/lambda/cmd/lifecycle/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/provider"
+)
+
+func main() {
+	ctx := context.Background()
+
+	bundle, err := provider.New(ctx, os.Getenv("CLOUD_PROVIDER"))
+	if err != nil {
+		log.Fatalf("provider.New: %v", err)
+	}
+	defer bundle.Close()
+
+	h := lifecycle.New(bundle.State, bundle.GitHub, log.Default())
+
+	lambda.Start(func(ctx context.Context, ev events.SQSEvent) error {
+		for _, rec := range ev.Records {
+			if err := h.HandleSQS(ctx, []byte(rec.Body)); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/lambda/cmd/scaledown/main.go
+++ b/lambda/cmd/scaledown/main.go
@@ -12,10 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+	awssqs "github.com/aws/aws-sdk-go-v2/service/sqs"
 
 	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/ec2"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
 )
 
 var (
@@ -41,18 +44,28 @@ func handler(ctx context.Context) error {
 
 	store := runner.NewStore(dynamodb.NewFromConfig(awsCfg), cfg.TableName)
 	launcher := ec2.NewLauncher(awsec2.NewFromConfig(awsCfg))
+	publisher := sqs.NewPublisher(awssqs.NewFromConfig(awsCfg), cfg.QueueURL)
+
+	// Phase E uses a tokenless GitHub client. DeregisterRunner is a no-op
+	// when the record's GitHubRunnerID is zero; non-zero IDs will fail with
+	// 401 and the cleanup path tolerates that (logged, not returned). Phase
+	// F will wire a real installation token resolver once runner records
+	// carry the InstallationID.
+	ghClient := github.NewClient("")
 
 	staleMinutes := envInt("STALE_THRESHOLD_MINUTES", 10)
 	maxAgeMinutes := envInt("MAX_RUNNER_AGE_MINUTES", 360)
+	maxReEnqueueAttempts := envInt("MAX_RE_ENQUEUE_ATTEMPTS", 3)
 
-	cleaner := runner.NewCleaner(store, launcher, staleMinutes, maxAgeMinutes)
+	cleaner := runner.NewCleaner(store, launcher, ghClient, publisher,
+		staleMinutes, maxAgeMinutes, maxReEnqueueAttempts)
 	result, err := cleaner.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("cleanup: %w", err)
 	}
 
 	log.Printf("cleanup complete: stale=%d orphans=%d errors=%d",
-		result.StaleTerminated, result.OrphanTerminated, result.Errors)
+		result.Stale, result.Orphans, result.Errors)
 	return nil
 }
 

--- a/lambda/cmd/scaledown/main.go
+++ b/lambda/cmd/scaledown/main.go
@@ -46,12 +46,19 @@ func handler(ctx context.Context) error {
 	launcher := ec2.NewLauncher(awsec2.NewFromConfig(awsCfg))
 	publisher := sqs.NewPublisher(awssqs.NewFromConfig(awsCfg), cfg.QueueURL)
 
-	// Phase E uses a tokenless GitHub client. DeregisterRunner is a no-op
-	// when the record's GitHubRunnerID is zero; non-zero IDs will fail with
-	// 401 and the cleanup path tolerates that (logged, not returned). Phase
-	// F will wire a real installation token resolver once runner records
-	// carry the InstallationID.
-	ghClient := github.NewClient("")
+	// Mint a real installation token at sweep start when GITHUB_INSTALLATION_ID
+	// is set so DeregisterRunner calls in terminateAndDeregister actually
+	// succeed. The Cleaner does not loop tokens per-record because (a) the
+	// token has a 60-min validity which is far longer than any sweep, and
+	// (b) DDB records do not carry a per-row installation_id (scaleup
+	// derives it from the SQS message; persistence is a Phase G concern).
+	// When InstallationID is unset we fall back to a tokenless client; the
+	// cleanup path already logs-and-continues on deregister failure so the
+	// sweep still terminates EC2 instances and updates DDB.
+	ghClient, err := newGitHubClient(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("github client: %w", err)
+	}
 
 	staleMinutes := envInt("STALE_THRESHOLD_MINUTES", 10)
 	maxAgeMinutes := envInt("MAX_RUNNER_AGE_MINUTES", 360)
@@ -74,6 +81,22 @@ func loadConfig(ctx context.Context) (*appconfig.Config, error) {
 		appCfg, cfgErr = appconfig.Load(ctx)
 	})
 	return appCfg, cfgErr
+}
+
+// newGitHubClient builds a *github.Client carrying a fresh installation
+// access token when cfg.InstallationID is set. When unset it returns a
+// tokenless client and logs a warning — DeregisterRunner will then 401,
+// but the cleanup path tolerates that (logs and continues).
+func newGitHubClient(ctx context.Context, cfg *appconfig.Config) (*github.Client, error) {
+	if cfg.InstallationID == 0 {
+		log.Printf("GITHUB_INSTALLATION_ID is unset: DeregisterRunner calls will 401; cleanup will still terminate EC2 + update DDB")
+		return github.NewClient(""), nil
+	}
+	token, err := github.InstallationToken(ctx, cfg.AppID, cfg.PrivateKey, cfg.InstallationID)
+	if err != nil {
+		return nil, fmt.Errorf("get installation token: %w", err)
+	}
+	return github.NewClient(token), nil
 }
 
 func envInt(key string, defaultVal int) int {

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/webhook"
 )
 
@@ -65,7 +67,7 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher *ec2.Lau
 
 	// Idempotency check.
 	existing, err := store.Get(ctx, msg.RepositoryFull, msg.JobID)
-	if err != nil {
+	if err != nil && !errors.Is(err, state.ErrNotFound) {
 		return fmt.Errorf("check existing runner: %w", err)
 	}
 	if existing != nil {

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -65,13 +66,18 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher *ec2.Lau
 		return nil // don't retry malformed messages
 	}
 
-	// Idempotency check.
+	// Idempotency check. Skip only when an in-flight runner is already
+	// registered and running. A pending record may be a partial write from a
+	// prior attempt that died before Launch — we still want to retry. A failed
+	// record (e.g. written by scaledown after a stale-pending reap) signals
+	// the runner was deregistered and the message has been re-enqueued, so a
+	// fresh registration + launch is appropriate.
 	existing, err := store.Get(ctx, msg.RepositoryFull, msg.JobID)
 	if err != nil && !errors.Is(err, state.ErrNotFound) {
 		return fmt.Errorf("check existing runner: %w", err)
 	}
-	if existing != nil {
-		log.Printf("runner already exists for %s job=%d, skipping", msg.RepositoryFull, msg.JobID)
+	if existing != nil && existing.Status == state.StatusRunning {
+		log.Printf("runner already running for %s job=%d, skipping", msg.RepositoryFull, msg.JobID)
 		return nil
 	}
 
@@ -81,13 +87,25 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher *ec2.Lau
 		return fmt.Errorf("get installation token: %w", err)
 	}
 
-	// Generate JIT runner config.
+	// Generate JIT runner config. Note the runner is registered with GitHub
+	// at this point; if anything below fails we must deregister it.
 	ghClient := github.NewClient(token)
 	runnerName := fmt.Sprintf("jit-%d", msg.JobID)
 	customLabels := webhook.CustomLabels(msg.Labels)
 	jitCfg, err := ghClient.GenerateJITConfig(ctx, msg.RepositoryFull, runnerName, msg.Labels)
 	if err != nil {
 		return fmt.Errorf("generate JIT config: %w", err)
+	}
+
+	// Persist a pending DDB record BEFORE launching the EC2 instance so that
+	// scaledown's stale-pending sweep can reap orphans if scaleup itself dies
+	// between RunInstances and the post-launch update. The record carries the
+	// GitHub runner ID (for deregistration) and the re-enqueue counter.
+	rec := runner.NewRecord(msg.RepositoryFull, msg.JobID, msg.RunID, "", msg.Labels)
+	rec.GitHubRunnerID = jitCfg.Runner.ID
+	rec.ReEnqueueAttempts = msg.ReEnqueueAttempts
+	if err := writePendingRecord(ctx, ghClient, store, msg, rec, existing != nil); err != nil {
+		return err
 	}
 
 	// Resolve instance type from labels.
@@ -103,6 +121,7 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher *ec2.Lau
 		JITConfig:     jitCfg.EncodedJIT,
 	})
 	if err != nil {
+		markLaunchFailed(ctx, ghClient, store, msg, rec.RunnerID, jitCfg.Runner.ID)
 		return fmt.Errorf("generate user-data: %w", err)
 	}
 
@@ -133,18 +152,82 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher *ec2.Lau
 		log.Printf("spot launch failed for %s job=%d: %v, trying on-demand", msg.RepositoryFull, msg.JobID, err)
 		instanceID, err = launcher.LaunchOnDemand(ctx, launchCfg)
 		if err != nil {
+			markLaunchFailed(ctx, ghClient, store, msg, rec.RunnerID, jitCfg.Runner.ID)
 			return fmt.Errorf("launch EC2 instance (spot and on-demand both failed): %w", err)
 		}
 	}
 
-	// Record runner state.
-	rec := runner.NewRecord(msg.RepositoryFull, msg.JobID, msg.RunID, instanceID, msg.Labels)
-	if err := store.Put(ctx, rec); err != nil {
-		log.Printf("failed to record runner state (instance %s already launched): %v", instanceID, err)
+	// Launch succeeded — bind the instance ID and bump LastAttemptAt on the
+	// pending record. The record stays in StatusPending; the runner agent on
+	// the instance will flip it to running via the lifecycle pipeline.
+	now := time.Now()
+	if err := store.Update(ctx, rec.RunnerID, state.RunnerUpdate{
+		InstanceID:    &instanceID,
+		LastAttemptAt: &now,
+	}); err != nil {
+		// The instance is launched and the runner is registered — log and
+		// continue so the message is ack'd. Scaledown will reconcile via tags
+		// if anything goes wrong from here.
+		log.Printf("failed to update runner record with instance %s for %s job=%d: %v",
+			instanceID, msg.RepositoryFull, msg.JobID, err)
 	}
 
 	log.Printf("launched instance %s for %s job=%d", instanceID, msg.RepositoryFull, msg.JobID)
 	return nil
+}
+
+// writePendingRecord persists rec as the pending pre-launch state. If a
+// non-running record already exists (recordExists=true), the writer Updates
+// the existing row instead of Putting (which would conflict with the
+// attribute_not_exists guard). Any failure deregisters the GitHub runner so
+// we don't leak registration state.
+func writePendingRecord(ctx context.Context, gh *github.Client, store *runner.Store, msg *sqs.ScaleUpMessage, rec *runner.Record, recordExists bool) error {
+	if !recordExists {
+		if err := store.Put(ctx, rec); err != nil {
+			if derr := gh.DeregisterRunner(ctx, msg.RepositoryFull, rec.GitHubRunnerID); derr != nil {
+				log.Printf("deregister after pending-put failure for %s job=%d: %v", msg.RepositoryFull, msg.JobID, derr)
+			}
+			return fmt.Errorf("put pending runner record: %w", err)
+		}
+		return nil
+	}
+	// Refresh the existing non-running record (typically pending or failed
+	// from a prior attempt) so the GitHub runner ID and re-enqueue counter
+	// reflect the current attempt before launch.
+	now := time.Now()
+	pending := state.StatusPending
+	ghID := rec.GitHubRunnerID
+	attempts := rec.ReEnqueueAttempts
+	if err := store.Update(ctx, rec.RunnerID, state.RunnerUpdate{
+		Status:            &pending,
+		GitHubRunnerID:    &ghID,
+		ReEnqueueAttempts: &attempts,
+		LastAttemptAt:     &now,
+	}); err != nil {
+		if derr := gh.DeregisterRunner(ctx, msg.RepositoryFull, rec.GitHubRunnerID); derr != nil {
+			log.Printf("deregister after pending-update failure for %s job=%d: %v", msg.RepositoryFull, msg.JobID, derr)
+		}
+		return fmt.Errorf("refresh pending runner record: %w", err)
+	}
+	return nil
+}
+
+// markLaunchFailed deregisters the GitHub-side runner registration and marks
+// the DDB record failed after a post-registration error path. Errors are
+// logged but not returned — the caller is already returning the launch error.
+func markLaunchFailed(ctx context.Context, gh *github.Client, store *runner.Store, msg *sqs.ScaleUpMessage, recordID string, runnerID int64) {
+	if err := gh.DeregisterRunner(ctx, msg.RepositoryFull, runnerID); err != nil {
+		log.Printf("deregister runner %d after launch failure for %s job=%d: %v",
+			runnerID, msg.RepositoryFull, msg.JobID, err)
+	}
+	now := time.Now()
+	failed := state.StatusFailed
+	if err := store.Update(ctx, recordID, state.RunnerUpdate{
+		Status:        &failed,
+		LastAttemptAt: &now,
+	}); err != nil {
+		log.Printf("mark runner failed for %s job=%d: %v", msg.RepositoryFull, msg.JobID, err)
+	}
 }
 
 func resolveInstanceType(cfg *appconfig.Config, labels []string) string {

--- a/lambda/cmd/webhook/main.go
+++ b/lambda/cmd/webhook/main.go
@@ -14,15 +14,17 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 
 	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
-	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
 	sqspub "github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/webhook"
 )
 
 var (
-	cfgOnce sync.Once
-	appCfg  *appconfig.Config
-	cfgErr  error
+	cfgOnce     sync.Once
+	appCfg      *appconfig.Config
+	cfgErr      error
+	handlerOnce sync.Once
+	wHandler    *webhook.Handler
+	handlerErr  error
 )
 
 func main() {
@@ -47,55 +49,17 @@ func handler(ctx context.Context, req events.LambdaFunctionURLRequest) (events.L
 	sig := getHeader(req.Headers, "x-hub-signature-256")
 	eventType := getHeader(req.Headers, "x-github-event")
 
-	cfg, err := loadConfig(ctx)
+	h, err := loadHandler(ctx)
 	if err != nil {
-		log.Printf("load config: %v", err)
+		log.Printf("init handler: %v", err)
 		return response(500, "Configuration error"), nil
 	}
 
-	if err := github.VerifyWebhookSignature([]byte(body), sig, cfg.WebhookSecret); err != nil {
-		log.Printf("verify signature: %v", err)
-		return response(401, "Invalid signature"), nil
+	resp := h.Handle(ctx, eventType, sig, []byte(body))
+	if resp.Status >= 500 {
+		log.Printf("handle webhook: %s", resp.String())
 	}
-
-	if eventType != "workflow_job" {
-		return response(200, "OK"), nil
-	}
-
-	result, err := webhook.Parse([]byte(body))
-	if err != nil {
-		log.Printf("parse workflow_job: %v", err)
-		return response(400, "Bad payload"), nil
-	}
-
-	if !result.ShouldScale {
-		log.Printf("workflow_job %s action=%s: no scaling needed", result.Event.Repository.FullName, result.Action)
-		return response(200, "OK"), nil
-	}
-
-	// Publish scale-up message to SQS.
-	awsCfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		log.Printf("load AWS config: %v", err)
-		return response(500, "AWS config error"), nil
-	}
-	publisher := sqspub.NewPublisher(sqs.NewFromConfig(awsCfg), cfg.QueueURL)
-
-	msg := &sqspub.ScaleUpMessage{
-		EventAction:    result.Action,
-		JobID:          result.Event.WorkflowJob.ID,
-		RunID:          result.Event.WorkflowJob.RunID,
-		RepositoryFull: result.Event.Repository.FullName,
-		Labels:         result.Event.WorkflowJob.Labels,
-		InstallationID: result.Event.Installation.ID,
-	}
-	if err := publisher.Publish(ctx, msg); err != nil {
-		log.Printf("publish SQS message: %v", err)
-		return response(500, "Queue error"), nil
-	}
-
-	log.Printf("queued scale-up for %s job=%d", msg.RepositoryFull, msg.JobID)
-	return response(200, "OK"), nil
+	return response(resp.Status, resp.Body), nil
 }
 
 func loadConfig(ctx context.Context) (*appconfig.Config, error) {
@@ -103,6 +67,43 @@ func loadConfig(ctx context.Context) (*appconfig.Config, error) {
 		appCfg, cfgErr = appconfig.Load(ctx)
 	})
 	return appCfg, cfgErr
+}
+
+// loadHandler builds the webhook.Handler exactly once per Lambda container.
+// Both publishers are wired here:
+//
+//   - scale-up:  SQS_QUEUE_URL          -> internal/sqs.Publisher
+//   - lifecycle: LIFECYCLE_QUEUE_URL    -> internal/sqs.LifecyclePublisher
+//
+// LIFECYCLE_QUEUE_URL is required for the in_progress/completed dispatch path
+// added in Phase C; absent it, lifecycle requests will return 500 from the
+// handler. We surface the missing-env case as a config error here so the
+// Lambda fails fast on cold start when misconfigured.
+func loadHandler(ctx context.Context) (*webhook.Handler, error) {
+	handlerOnce.Do(func() {
+		cfg, err := loadConfig(ctx)
+		if err != nil {
+			handlerErr = err
+			return
+		}
+		awsCfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			handlerErr = err
+			return
+		}
+		client := sqs.NewFromConfig(awsCfg)
+		scaleUpPub := sqspub.NewPublisher(client, cfg.QueueURL)
+
+		lifecycleURL := os.Getenv("LIFECYCLE_QUEUE_URL")
+		if lifecycleURL == "" {
+			log.Printf("LIFECYCLE_QUEUE_URL is empty: lifecycle events will return 500 until set")
+			wHandler = webhook.NewHandler(scaleUpPub, nil, []byte(cfg.WebhookSecret))
+			return
+		}
+		lifecyclePub := sqspub.NewLifecyclePublisher(client, lifecycleURL)
+		wHandler = webhook.NewHandler(scaleUpPub, lifecyclePub, []byte(cfg.WebhookSecret))
+	})
+	return wHandler, handlerErr
 }
 
 func response(status int, body string) events.LambdaFunctionURLResponse {

--- a/lambda/internal/config/config.go
+++ b/lambda/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -18,6 +19,15 @@ type Config struct {
 	AppID         string
 	PrivateKey    string //nolint:gosec // G117: not a hardcoded credential, loaded from env/secrets manager
 	WebhookSecret string
+
+	// InstallationID is the GitHub App installation this Lambda authenticates
+	// against when minting installation access tokens at startup (used by the
+	// scaledown Cleaner and lifecycle handler, which operate on records that
+	// do not carry a per-message installation_id). Optional: when zero the
+	// caller falls back to a tokenless GitHub client and DeregisterRunner
+	// calls will 401 in production. Scaleup is unaffected because it derives
+	// the installation from the SQS message payload directly.
+	InstallationID int64
 
 	// SQS queue URL for scale-up messages.
 	QueueURL string
@@ -79,6 +89,17 @@ func LoadWithClient(ctx context.Context, client SecretsReader) (*Config, error) 
 	// Parse subnet IDs (comma-separated).
 	if subnets := os.Getenv("EC2_SUBNET_IDS"); subnets != "" {
 		cfg.SubnetIDs = strings.Split(subnets, ",")
+	}
+
+	// Parse optional GitHub App installation ID. Required for the scaledown
+	// Cleaner and lifecycle handler to mint installation tokens for
+	// DeregisterRunner; ignored by webhook + scaleup.
+	if v := os.Getenv("GITHUB_INSTALLATION_ID"); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse GITHUB_INSTALLATION_ID %q: %w", v, err)
+		}
+		cfg.InstallationID = n
 	}
 
 	// Parse label mappings from JSON.

--- a/lambda/internal/config/config_test.go
+++ b/lambda/internal/config/config_test.go
@@ -101,6 +101,44 @@ func TestLoad_Success(t *testing.T) {
 	if len(cfg.LabelMappings) != 1 || cfg.LabelMappings[0].Label != "gpu" {
 		t.Errorf("LabelMappings = %v", cfg.LabelMappings)
 	}
+	if cfg.InstallationID != 0 {
+		t.Errorf("InstallationID = %d, want 0 (unset)", cfg.InstallationID)
+	}
+}
+
+func TestLoad_InstallationID(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("GITHUB_APP_ID", "12345")
+		t.Setenv("SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123/queue")
+		t.Setenv("DYNAMODB_TABLE_NAME", "runners")
+		t.Setenv("GITHUB_APP_WEBHOOK_SECRET", "my-secret")
+		t.Setenv("GITHUB_APP_PRIVATE_KEY", "my-private-key")
+		t.Setenv("GITHUB_INSTALLATION_ID", "987654")
+
+		cfg, err := Load(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.InstallationID != 987654 {
+			t.Errorf("InstallationID = %d, want 987654", cfg.InstallationID)
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		clearEnv(t)
+		t.Setenv("GITHUB_APP_ID", "12345")
+		t.Setenv("SQS_QUEUE_URL", "https://sqs.us-east-1.amazonaws.com/123/queue")
+		t.Setenv("DYNAMODB_TABLE_NAME", "runners")
+		t.Setenv("GITHUB_APP_WEBHOOK_SECRET", "my-secret")
+		t.Setenv("GITHUB_APP_PRIVATE_KEY", "my-private-key")
+		t.Setenv("GITHUB_INSTALLATION_ID", "not-a-number")
+
+		_, err := Load(context.Background())
+		if err == nil {
+			t.Fatal("expected parse error, got nil")
+		}
+	})
 }
 
 func clearEnv(t *testing.T) {
@@ -109,6 +147,7 @@ func clearEnv(t *testing.T) {
 		"GITHUB_APP_ID", "SQS_QUEUE_URL", "DYNAMODB_TABLE_NAME",
 		"GITHUB_APP_WEBHOOK_SECRET", "GITHUB_APP_WEBHOOK_SECRET_ARN",
 		"GITHUB_APP_PRIVATE_KEY", "GITHUB_APP_PRIVATE_KEY_SECRET_ARN",
+		"GITHUB_INSTALLATION_ID",
 		"EC2_SUBNET_IDS", "EC2_SECURITY_GROUP_ID", "EC2_IAM_INSTANCE_PROFILE",
 		"EC2_DEFAULT_AMI", "LABEL_MAPPINGS",
 	}

--- a/lambda/internal/github/client.go
+++ b/lambda/internal/github/client.go
@@ -148,3 +148,30 @@ func (c *Client) GenerateJITConfig(ctx context.Context, ownerRepo string, name s
 	}
 	return &cfg, nil
 }
+
+// DeregisterRunner deletes a self-hosted runner registration on GitHub.
+// Returns nil for both 204 (deleted) and 404 (already gone) so callers can
+// invoke this unconditionally on cleanup paths. A zero runnerID is a no-op.
+func (c *Client) DeregisterRunner(ctx context.Context, ownerRepo string, runnerID int64) error {
+	if runnerID <= 0 {
+		return nil // nothing to deregister
+	}
+	url := fmt.Sprintf("%s/repos/%s/actions/runners/%d", c.baseURL, ownerRepo, runnerID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("github: DeregisterRunner build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from GitHub API constant
+	if err != nil {
+		return fmt.Errorf("github: DeregisterRunner %d: %w", runnerID, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort close
+	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	return fmt.Errorf("github: DeregisterRunner %d: status %d", runnerID, resp.StatusCode)
+}

--- a/lambda/internal/github/client.go
+++ b/lambda/internal/github/client.go
@@ -95,9 +95,20 @@ func installationTokenWithBase(ctx context.Context, appID, privateKeyPEM string,
 }
 
 // JITRunnerConfig holds the response from the JIT runner config generation API.
+// The shape mirrors the GitHub REST response:
+//
+//	{ "runner": { "id": 99, "name": "..." }, "encoded_jit_config": "..." }
 type JITRunnerConfig struct {
-	RunnerID   int64  `json:"runner_id"`
-	EncodedJIT string `json:"encoded_jit_config"`
+	Runner     JITRunner `json:"runner"`
+	EncodedJIT string    `json:"encoded_jit_config"`
+}
+
+// JITRunner is the nested runner identity returned alongside the encoded JIT
+// config. The ID is required to deregister the runner from GitHub if scaleup
+// later fails to launch the EC2 instance, or for end-of-job cleanup.
+type JITRunner struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 // GenerateJITConfig requests a just-in-time runner configuration from GitHub.

--- a/lambda/internal/github/client_test.go
+++ b/lambda/internal/github/client_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_DeregisterRunner(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		wantErr bool
+	}{
+		{"204 deleted", http.StatusNoContent, false},
+		{"404 already gone", http.StatusNotFound, false},
+		{"500 server error", http.StatusInternalServerError, true},
+		{"502 bad gateway", http.StatusBadGateway, true},
+		{"403 forbidden", http.StatusForbidden, true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got, want := r.Method, http.MethodDelete; got != want {
+					t.Errorf("method: got %s want %s", got, want)
+				}
+				if got, want := r.URL.Path, "/repos/owner/repo/actions/runners/42"; got != want {
+					t.Errorf("path: got %s want %s", got, want)
+				}
+				if got, want := r.Header.Get("Authorization"), "Bearer test-token"; got != want {
+					t.Errorf("auth: got %q want %q", got, want)
+				}
+				if got, want := r.Header.Get("Accept"), "application/vnd.github+json"; got != want {
+					t.Errorf("accept: got %q want %q", got, want)
+				}
+				if got, want := r.Header.Get("X-GitHub-Api-Version"), "2022-11-28"; got != want {
+					t.Errorf("api-version: got %q want %q", got, want)
+				}
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+
+			c := NewClientWithBase("test-token", srv.URL)
+			c.httpClient = srv.Client()
+			err := c.DeregisterRunner(context.Background(), "owner/repo", 42)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for status %d, got nil", tc.status)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error for status %d: %v", tc.status, err)
+			}
+		})
+	}
+}
+
+func TestClient_DeregisterRunner_ZeroID(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBase("tok", srv.URL)
+	c.httpClient = srv.Client()
+	if err := c.DeregisterRunner(context.Background(), "owner/repo", 0); err != nil {
+		t.Fatalf("zero ID should be no-op, got error: %v", err)
+	}
+	if called {
+		t.Fatal("zero ID should not hit the network")
+	}
+}
+
+func TestClient_DeregisterRunner_NegativeID(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+
+	c := NewClientWithBase("tok", srv.URL)
+	c.httpClient = srv.Client()
+	if err := c.DeregisterRunner(context.Background(), "owner/repo", -1); err != nil {
+		t.Fatalf("negative ID should be no-op, got error: %v", err)
+	}
+	if called {
+		t.Fatal("negative ID should not hit the network")
+	}
+}

--- a/lambda/internal/lifecycle/handler.go
+++ b/lambda/internal/lifecycle/handler.go
@@ -1,0 +1,88 @@
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// runnerID computes the DDB primary key from repo + jobID. Mirrors the
+// scaleup helper. A future refactor (Phase B3 in the plan) consolidates
+// this in the runner package; for now it is local to lifecycle to keep
+// this branch self-contained.
+func runnerID(repo string, jobID int64) string {
+	return fmt.Sprintf("%s#%d", repo, jobID)
+}
+
+// nextStatus is the forward-only state-machine transition table.
+// (current, action) -> (next, ok). ok=false means: drop the message
+// (backward transition or unknown action). next == current means: no-op.
+func nextStatus(current, action string) (next string, ok bool) {
+	switch action {
+	case "in_progress":
+		switch current {
+		case state.StatusPending:
+			return state.StatusRunning, true
+		case state.StatusRunning:
+			return current, true // no-op (already running)
+		}
+		return current, false
+	case "completed":
+		switch current {
+		case state.StatusPending, state.StatusRunning:
+			return state.StatusCompleted, true
+		case state.StatusCompleted:
+			return current, true // no-op (already completed)
+		}
+		return current, false
+	}
+	return current, false
+}
+
+// HandleSQS processes one SQS record body. Idempotent.
+func (h *Handler) HandleSQS(ctx context.Context, body []byte) error {
+	var msg Message
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return fmt.Errorf("lifecycle: parse: %w", err)
+	}
+
+	key := runnerID(msg.Repo, msg.JobID)
+	rec, err := h.Store.Get(ctx, key)
+	switch {
+	case errors.Is(err, state.ErrNotFound):
+		h.Logger.Printf("lifecycle: drop %s job=%d action=%s: no record", msg.Repo, msg.JobID, msg.Action)
+		return nil
+	case err != nil:
+		return fmt.Errorf("lifecycle: get %s: %w", key, err)
+	}
+
+	next, ok := nextStatus(rec.Status, msg.Action)
+	if !ok {
+		h.Logger.Printf("lifecycle: drop %s job=%d action=%s: backward transition from %s",
+			msg.Repo, msg.JobID, msg.Action, rec.Status)
+		return nil
+	}
+	if next == rec.Status {
+		return nil // same-state no-op
+	}
+
+	now := time.Now()
+	if err := h.Store.Update(ctx, key, state.RunnerUpdate{
+		Status:        &next,
+		LastAttemptAt: &now,
+	}); err != nil {
+		return fmt.Errorf("lifecycle: update %s: %w", key, err)
+	}
+
+	if msg.Action == "completed" && rec.GitHubRunnerID > 0 {
+		if err := h.GitHub.DeregisterRunner(ctx, msg.Repo, rec.GitHubRunnerID); err != nil {
+			h.Logger.Printf("lifecycle: deregister %d (%s): %v", rec.GitHubRunnerID, msg.Repo, err)
+			// do not fail the message: DDB is committed; deregister is best-effort.
+		}
+	}
+	return nil
+}

--- a/lambda/internal/lifecycle/handler_test.go
+++ b/lambda/internal/lifecycle/handler_test.go
@@ -1,0 +1,173 @@
+package lifecycle
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// fakeStore implements state.RunnerStore for tests.
+type fakeStore struct {
+	get       state.Runner
+	getErr    error
+	updates   []updateCall
+	updateErr error
+}
+
+type updateCall struct {
+	id     string
+	fields state.RunnerUpdate
+}
+
+func (f *fakeStore) Get(_ context.Context, _ string) (state.Runner, error) {
+	return f.get, f.getErr
+}
+
+func (f *fakeStore) Put(_ context.Context, _ state.Runner) error { return nil }
+
+func (f *fakeStore) List(_ context.Context, _ state.Filter) ([]state.Runner, error) {
+	return nil, nil
+}
+
+func (f *fakeStore) Delete(_ context.Context, _ string) error { return nil }
+
+func (f *fakeStore) Update(_ context.Context, id string, u state.RunnerUpdate) error {
+	f.updates = append(f.updates, updateCall{id: id, fields: u})
+	return f.updateErr
+}
+
+// fakeGitHub records DeregisterRunner calls.
+type fakeGitHub struct {
+	calls []dereg
+	err   error
+}
+
+type dereg struct {
+	repo     string
+	runnerID int64
+}
+
+func (f *fakeGitHub) DeregisterRunner(_ context.Context, repo string, runnerID int64) error {
+	f.calls = append(f.calls, dereg{repo: repo, runnerID: runnerID})
+	return f.err
+}
+
+func testLogger() *log.Logger {
+	return log.New(os.Stderr, "test ", 0)
+}
+
+func TestHandleSQS_TransitionTable(t *testing.T) {
+	cases := []struct {
+		name           string
+		current        string
+		action         string
+		ghRunnerID     int64
+		wantNextStatus string
+		wantUpdate     bool
+		wantDeregister bool
+	}{
+		{"pending+in_progress -> running", state.StatusPending, "in_progress", 99, state.StatusRunning, true, false},
+		{"running+completed -> completed (deregister)", state.StatusRunning, "completed", 99, state.StatusCompleted, true, true},
+		{"pending+completed -> completed (out-of-order, deregister)", state.StatusPending, "completed", 99, state.StatusCompleted, true, true},
+		{"completed+completed -> no-op", state.StatusCompleted, "completed", 99, state.StatusCompleted, false, false},
+		{"failed+in_progress -> drop (backward)", state.StatusFailed, "in_progress", 99, state.StatusFailed, false, false},
+		{"completed+in_progress -> drop (backward)", state.StatusCompleted, "in_progress", 99, state.StatusCompleted, false, false},
+		{"running+in_progress -> no-op", state.StatusRunning, "in_progress", 99, state.StatusRunning, false, false},
+		{"completed+unknown_action -> drop", state.StatusCompleted, "waiting", 99, state.StatusCompleted, false, false},
+		{"completed with zero runnerID -> update only", state.StatusRunning, "completed", 0, state.StatusCompleted, true, false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakeStore{get: state.Runner{
+				ID:             "owner/repo#1",
+				Status:         tc.current,
+				GitHubRunnerID: tc.ghRunnerID,
+			}}
+			gh := &fakeGitHub{}
+			h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+
+			body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"` + tc.action + `"}`)
+			if err := h.HandleSQS(context.Background(), body); err != nil {
+				t.Fatalf("HandleSQS: %v", err)
+			}
+
+			gotUpdate := len(store.updates) == 1
+			if gotUpdate != tc.wantUpdate {
+				t.Errorf("update: got %v want %v (updates=%+v)", gotUpdate, tc.wantUpdate, store.updates)
+			}
+			if tc.wantUpdate {
+				if store.updates[0].fields.Status == nil {
+					t.Fatal("Status: expected non-nil pointer")
+				}
+				if got := *store.updates[0].fields.Status; got != tc.wantNextStatus {
+					t.Errorf("status: got %q want %q", got, tc.wantNextStatus)
+				}
+				if store.updates[0].fields.LastAttemptAt == nil {
+					t.Error("LastAttemptAt: expected non-nil")
+				}
+			}
+
+			gotDereg := len(gh.calls) == 1
+			if gotDereg != tc.wantDeregister {
+				t.Errorf("deregister: got %v want %v (calls=%+v)", gotDereg, tc.wantDeregister, gh.calls)
+			}
+			if tc.wantDeregister {
+				if gh.calls[0].runnerID != tc.ghRunnerID {
+					t.Errorf("deregister runnerID: got %d want %d", gh.calls[0].runnerID, tc.ghRunnerID)
+				}
+				if gh.calls[0].repo != "owner/repo" {
+					t.Errorf("deregister repo: got %q want %q", gh.calls[0].repo, "owner/repo")
+				}
+			}
+		})
+	}
+}
+
+func TestHandleSQS_UnknownRecordDrops(t *testing.T) {
+	store := &fakeStore{getErr: state.ErrNotFound}
+	gh := &fakeGitHub{}
+	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","action":"completed"}`)
+	if err := h.HandleSQS(context.Background(), body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(store.updates) != 0 {
+		t.Errorf("expected no updates, got %+v", store.updates)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("expected no deregister, got %+v", gh.calls)
+	}
+}
+
+func TestHandleSQS_DeregisterErrorDoesNotFail(t *testing.T) {
+	store := &fakeStore{get: state.Runner{Status: state.StatusRunning, GitHubRunnerID: 99}}
+	gh := &fakeGitHub{err: errors.New("network blip")}
+	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","action":"completed"}`)
+	if err := h.HandleSQS(context.Background(), body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(store.updates) != 1 {
+		t.Errorf("DDB should still be updated when deregister fails; got %d updates", len(store.updates))
+	}
+	if len(gh.calls) != 1 {
+		t.Errorf("expected one deregister attempt, got %d", len(gh.calls))
+	}
+}
+
+func TestHandleSQS_BadJSONReturnsError(t *testing.T) {
+	store := &fakeStore{}
+	gh := &fakeGitHub{}
+	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+
+	if err := h.HandleSQS(context.Background(), []byte(`{not json`)); err == nil {
+		t.Fatal("expected parse error")
+	}
+}

--- a/lambda/internal/lifecycle/message.go
+++ b/lambda/internal/lifecycle/message.go
@@ -1,0 +1,12 @@
+// Package lifecycle handles workflow_job in_progress and completed events.
+package lifecycle
+
+// Message is the payload published by webhook to the lifecycle queue.
+// Mirrors the subset of GitHub's workflow_job event the handler needs.
+type Message struct {
+	JobID      int64  `json:"job_id"`
+	Repo       string `json:"repo"`       // "owner/repo"
+	RunnerID   int64  `json:"runner_id"`  // 0 if GH didn't assign one
+	Action     string `json:"action"`     // "in_progress" | "completed"
+	Conclusion string `json:"conclusion"` // "" for in_progress; success/failure/cancelled/skipped for completed
+}

--- a/lambda/internal/lifecycle/types.go
+++ b/lambda/internal/lifecycle/types.go
@@ -1,0 +1,30 @@
+package lifecycle
+
+import (
+	"context"
+	"log"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// ghClient is the subset of the GitHub client the lifecycle handler needs.
+// Defined as an interface so tests can substitute a fake without importing
+// the real github package or its transport dependencies.
+type ghClient interface {
+	DeregisterRunner(ctx context.Context, ownerRepo string, runnerID int64) error
+}
+
+// Handler dispatches lifecycle messages to DDB updates and GitHub deregister calls.
+type Handler struct {
+	Store  state.RunnerStore
+	GitHub ghClient
+	Logger *log.Logger
+}
+
+// New constructs a Handler with sane defaults (stdlib logger if nil).
+func New(store state.RunnerStore, gh ghClient, logger *log.Logger) *Handler {
+	if logger == nil {
+		logger = log.Default()
+	}
+	return &Handler{Store: store, GitHub: gh, Logger: logger}
+}

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -2,137 +2,252 @@ package runner
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"time"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
 
-// EC2Terminator abstracts EC2 instance termination for testing.
+// EC2Terminator abstracts EC2 instance termination for the cleanup path.
+// It is satisfied by *ec2.Launcher.
 type EC2Terminator interface {
 	Terminate(ctx context.Context, instanceIDs ...string) error
-	ListManagedInstances(ctx context.Context) ([]string, error)
 }
 
-// Cleaner handles stale and orphaned runner cleanup.
+// ghClient is the narrow surface of the GitHub client used by Cleaner.
+// Defined locally so unit tests can fake it without importing the real
+// github package. Satisfied by *github.Client.
+type ghClient interface {
+	DeregisterRunner(ctx context.Context, ownerRepo string, runnerID int64) error
+}
+
+// scaleupPublisher is the narrow surface of the SQS publisher used by
+// Cleaner to re-enqueue stale-pending records. Satisfied by *sqs.Publisher.
+type scaleupPublisher interface {
+	Publish(ctx context.Context, msg *sqs.ScaleUpMessage) error
+}
+
+// Cleaner reaps stale runner records and (for stale-pending) re-enqueues a
+// fresh launch attempt with an attempt counter. Stale-running records are
+// terminated but NEVER re-enqueued — re-enqueueing a running record can
+// double-launch when GitHub may already consider the job done.
 type Cleaner struct {
-	store                 *Store
-	ec2                   EC2Terminator
-	staleThresholdMinutes int
-	maxAgeMinutes         int
+	Store            *Store
+	Launcher         EC2Terminator
+	GitHub           ghClient
+	ScaleUpPublisher scaleupPublisher
+
+	// StaleAfter is the threshold applied to status=pending records.
+	// A pending record older than now-StaleAfter is considered stuck.
+	StaleAfter time.Duration
+	// MaxAge is the threshold applied to status=running records. A running
+	// record older than now-MaxAge is reaped (terminated + marked failed).
+	MaxAge time.Duration
+	// MaxReEnqueueAttempts is the budget for stale-pending re-enqueues.
+	// When ReEnqueueAttempts has reached this value the record is marked
+	// terminal failed and an ERROR is logged instead of re-publishing.
+	MaxReEnqueueAttempts int
+
+	// Now is injectable for tests; defaults to time.Now if unset.
+	Now func() time.Time
 }
 
-// NewCleaner creates a Cleaner with the given thresholds.
-func NewCleaner(store *Store, ec2 EC2Terminator, staleMinutes, maxAgeMinutes int) *Cleaner {
+// NewCleaner builds a Cleaner. staleMinutes and maxAgeMinutes apply to
+// pending and running records respectively; maxReEnqueueAttempts caps the
+// number of times a stale-pending record may be re-published.
+func NewCleaner(
+	store *Store,
+	launcher EC2Terminator,
+	gh ghClient,
+	pub scaleupPublisher,
+	staleMinutes, maxAgeMinutes, maxReEnqueueAttempts int,
+) *Cleaner {
 	if staleMinutes <= 0 {
 		staleMinutes = 10
 	}
 	if maxAgeMinutes <= 0 {
 		maxAgeMinutes = 360 // 6 hours
 	}
+	if maxReEnqueueAttempts < 0 {
+		maxReEnqueueAttempts = 0
+	}
 	return &Cleaner{
-		store:                 store,
-		ec2:                   ec2,
-		staleThresholdMinutes: staleMinutes,
-		maxAgeMinutes:         maxAgeMinutes,
+		Store:                store,
+		Launcher:             launcher,
+		GitHub:               gh,
+		ScaleUpPublisher:     pub,
+		StaleAfter:           time.Duration(staleMinutes) * time.Minute,
+		MaxAge:               time.Duration(maxAgeMinutes) * time.Minute,
+		MaxReEnqueueAttempts: maxReEnqueueAttempts,
+		Now:                  time.Now,
 	}
 }
 
-// CleanupResult summarizes the cleanup operation.
+// CleanupResult summarizes a cleanup pass.
+//
+// Stale counts records that were terminated (pending or running). Orphans
+// counts records that were processed by the stale-pending path (re-enqueued
+// or terminally failed because the budget was exhausted). Errors counts any
+// path where termination or publish failed and we abandoned the record.
 type CleanupResult struct {
-	StaleTerminated  int
-	OrphanTerminated int
-	Errors           int
+	Stale   int
+	Orphans int
+	Errors  int
 }
 
 // Run executes the cleanup logic:
-// 1. Terminate pending instances older than staleThreshold.
-// 2. Terminate running instances older than maxAge.
-// 3. Reconcile EC2 instances vs DynamoDB records for orphans.
+//  1. Stale-pending sweep — terminate, deregister, re-enqueue if budget
+//     remains, otherwise mark terminal failed.
+//  2. Stale-running sweep — terminate, deregister, mark failed. NEVER
+//     re-enqueue a running record.
 func (c *Cleaner) Run(ctx context.Context) (*CleanupResult, error) {
 	result := &CleanupResult{}
-	now := time.Now().Unix()
+	now := c.now()
 
-	// 1. Clean up stale "pending" instances.
-	pending, err := c.store.ListByStatus(ctx, StatusPending)
+	pending, err := c.Store.ListByStatus(ctx, StatusPending)
 	if err != nil {
 		return result, err
 	}
-	staleThreshold := now - int64(c.staleThresholdMinutes*60)
-	if err := c.cleanupStaleInstances(ctx, pending, staleThreshold, "pending", result); err != nil {
-		return result, err
-	}
+	staleCutoff := now.Add(-c.StaleAfter).Unix()
+	c.sweepStalePending(ctx, pending, staleCutoff, now, result)
 
-	// 2. Clean up stuck "running" instances.
-	running, err := c.store.ListByStatus(ctx, StatusRunning)
+	running, err := c.Store.ListByStatus(ctx, StatusRunning)
 	if err != nil {
 		return result, err
 	}
-	maxAgeThreshold := now - int64(c.maxAgeMinutes*60)
-	if err := c.cleanupStaleInstances(ctx, running, maxAgeThreshold, "running", result); err != nil {
-		return result, err
-	}
-
-	// 3. Detect orphaned EC2 instances (tagged but not in DynamoDB).
-	allRecords := append(pending, running...)
-	completed, err := c.store.ListByStatus(ctx, StatusCompleted)
-	if err != nil {
-		return result, fmt.Errorf("list completed runners: %w", err)
-	}
-	failed, err := c.store.ListByStatus(ctx, StatusFailed)
-	if err != nil {
-		return result, fmt.Errorf("list failed runners: %w", err)
-	}
-	allRecords = append(allRecords, completed...)
-	allRecords = append(allRecords, failed...)
-
-	if err := c.reconcileOrphanInstances(ctx, allRecords, result); err != nil {
-		return result, err
-	}
+	runCutoff := now.Add(-c.MaxAge).Unix()
+	c.sweepStaleRunning(ctx, running, runCutoff, now, result)
 
 	return result, nil
 }
 
-// cleanupStaleInstances terminates instances that have been in the given status longer than the threshold.
-func (c *Cleaner) cleanupStaleInstances(ctx context.Context, records []*Record, threshold int64, statusLabel string, result *CleanupResult) error {
+// sweepStalePending handles status=pending records older than the cutoff:
+// terminate the EC2 instance (if any), deregister the GitHub runner (if
+// any), and either re-enqueue a fresh launch attempt or mark the record
+// terminal failed when the attempt budget is exhausted.
+func (c *Cleaner) sweepStalePending(ctx context.Context, records []*Record, cutoff int64, now time.Time, result *CleanupResult) {
 	for _, r := range records {
-		if r.CreatedAt < threshold {
-			log.Printf("cleanup: terminating stale %s runner %s (instance %s)", statusLabel, r.RunnerID, r.InstanceID)
-			if err := c.ec2.Terminate(ctx, r.InstanceID); err != nil {
-				log.Printf("cleanup: failed to terminate %s: %v", r.InstanceID, err)
+		if r.CreatedAt >= cutoff {
+			continue
+		}
+		log.Printf("cleanup: terminating stale pending runner %s (instance %s, attempts=%d)",
+			r.RunnerID, r.InstanceID, r.ReEnqueueAttempts)
+
+		if err := c.terminateAndDeregister(ctx, r); err != nil {
+			result.Errors++
+			continue
+		}
+		result.Stale++
+
+		if r.ReEnqueueAttempts < c.MaxReEnqueueAttempts {
+			next := r.ReEnqueueAttempts + 1
+			msg := &sqs.ScaleUpMessage{
+				EventAction:       "queued",
+				JobID:             r.JobID,
+				RunID:             r.RunID,
+				RepositoryFull:    r.Repository,
+				Labels:            r.Labels,
+				ReEnqueueAttempts: next,
+			}
+			if err := c.ScaleUpPublisher.Publish(ctx, msg); err != nil {
+				log.Printf("cleanup: re-enqueue publish failed for %s: %v", r.RunnerID, err)
 				result.Errors++
 				continue
 			}
-			if err := c.store.UpdateStatus(ctx, r.Repository, r.JobID, StatusFailed); err != nil {
-				log.Printf("cleanup: failed to update status for %s: %v", r.RunnerID, err)
+			failed := StatusFailed
+			at := now
+			attempts := next
+			if err := c.Store.Update(ctx, r.RunnerID, state.RunnerUpdate{
+				Status:            &failed,
+				ReEnqueueAttempts: &attempts,
+				LastAttemptAt:     &at,
+			}); err != nil {
+				log.Printf("cleanup: update after re-enqueue failed for %s: %v", r.RunnerID, err)
 				result.Errors++
 				continue
 			}
-			result.StaleTerminated++
+			result.Orphans++
+			continue
+		}
+
+		// Budget exhausted — mark terminal failed and log loudly. Do NOT
+		// re-enqueue: the message has been retried MaxReEnqueueAttempts
+		// times already and continued failure indicates a systemic issue
+		// that retries cannot resolve.
+		log.Printf("ERROR scaledown: re-enqueue exhausted for %s job=%d after %d attempts",
+			r.Repository, r.JobID, r.ReEnqueueAttempts)
+		failed := StatusFailed
+		at := now
+		if err := c.Store.Update(ctx, r.RunnerID, state.RunnerUpdate{
+			Status:        &failed,
+			LastAttemptAt: &at,
+		}); err != nil {
+			log.Printf("cleanup: update terminal failed for %s: %v", r.RunnerID, err)
+			result.Errors++
+			continue
+		}
+		result.Orphans++
+	}
+}
+
+// sweepStaleRunning handles status=running records older than the cutoff:
+// terminate the EC2 instance, deregister the GitHub runner, mark the record
+// failed. NEVER re-enqueue — a running record may correspond to a job that
+// GitHub already considers complete; re-enqueueing would risk a double
+// launch.
+func (c *Cleaner) sweepStaleRunning(ctx context.Context, records []*Record, cutoff int64, now time.Time, result *CleanupResult) {
+	for _, r := range records {
+		if r.CreatedAt >= cutoff {
+			continue
+		}
+		log.Printf("cleanup: reaping stale running runner %s (instance %s)", r.RunnerID, r.InstanceID)
+
+		if err := c.terminateAndDeregister(ctx, r); err != nil {
+			result.Errors++
+			continue
+		}
+		failed := StatusFailed
+		at := now
+		if err := c.Store.Update(ctx, r.RunnerID, state.RunnerUpdate{
+			Status:        &failed,
+			LastAttemptAt: &at,
+		}); err != nil {
+			log.Printf("cleanup: update failed for stale running %s: %v", r.RunnerID, err)
+			result.Errors++
+			continue
+		}
+		result.Stale++
+	}
+}
+
+// terminateAndDeregister performs the two outbound side-effects shared by
+// both sweep paths: kill the EC2 instance (if any) and deregister the
+// GitHub runner registration (if any). The deregister call returns nil for
+// 404 already, so non-404 errors are logged but do not block downstream
+// state updates — failing the cleanup pass entirely on a transient GitHub
+// outage would leave records stuck. Returns an error only on EC2
+// termination failure, which is the one case we cannot safely proceed
+// past (the instance may still be running).
+func (c *Cleaner) terminateAndDeregister(ctx context.Context, r *Record) error {
+	if r.InstanceID != "" {
+		if err := c.Launcher.Terminate(ctx, r.InstanceID); err != nil {
+			log.Printf("cleanup: terminate %s failed: %v", r.InstanceID, err)
+			return err
+		}
+	}
+	if r.GitHubRunnerID > 0 {
+		if err := c.GitHub.DeregisterRunner(ctx, r.Repository, r.GitHubRunnerID); err != nil {
+			log.Printf("cleanup: deregister runner %d for %s failed: %v",
+				r.GitHubRunnerID, r.Repository, err)
 		}
 	}
 	return nil
 }
 
-// reconcileOrphanInstances finds EC2 instances not tracked in DynamoDB and terminates them.
-func (c *Cleaner) reconcileOrphanInstances(ctx context.Context, knownRecords []*Record, result *CleanupResult) error {
-	managedIDs, err := c.ec2.ListManagedInstances(ctx)
-	if err != nil {
-		return err
+func (c *Cleaner) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
 	}
-	knownIDs := make(map[string]bool)
-	for _, r := range knownRecords {
-		knownIDs[r.InstanceID] = true
-	}
-	for _, id := range managedIDs {
-		if !knownIDs[id] {
-			log.Printf("cleanup: terminating orphaned instance %s", id)
-			if err := c.ec2.Terminate(ctx, id); err != nil {
-				log.Printf("cleanup: failed to terminate orphan %s: %v", id, err)
-				result.Errors++
-				continue
-			}
-			result.OrphanTerminated++
-		}
-	}
-	return nil
+	return time.Now()
 }

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -1,0 +1,612 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// scanFakeDDB is a richer fake that responds to Scan queries based on the
+// ":status" filter value so a single fake can serve both pending and
+// running list calls. It also captures every UpdateItem so tests can
+// assert which fields were written.
+type scanFakeDDB struct {
+	pending []*Record
+	running []*Record
+
+	updates []capturedUpdate
+}
+
+type capturedUpdate struct {
+	id     string
+	expr   string
+	values map[string]types.AttributeValue
+}
+
+func (f *scanFakeDDB) PutItem(_ context.Context, _ *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (f *scanFakeDDB) GetItem(_ context.Context, _ *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	return &dynamodb.GetItemOutput{}, nil
+}
+
+func (f *scanFakeDDB) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	id := ""
+	if v, ok := in.Key["runner_id"].(*types.AttributeValueMemberS); ok {
+		id = v.Value
+	}
+	expr := ""
+	if in.UpdateExpression != nil {
+		expr = *in.UpdateExpression
+	}
+	f.updates = append(f.updates, capturedUpdate{
+		id:     id,
+		expr:   expr,
+		values: in.ExpressionAttributeValues,
+	})
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (f *scanFakeDDB) Scan(_ context.Context, in *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	statusVal := ""
+	if v, ok := in.ExpressionAttributeValues[":status"].(*types.AttributeValueMemberS); ok {
+		statusVal = v.Value
+	}
+	var src []*Record
+	switch statusVal {
+	case StatusPending:
+		src = f.pending
+	case StatusRunning:
+		src = f.running
+	}
+	out := &dynamodb.ScanOutput{}
+	for _, r := range src {
+		item, err := attributevalue.MarshalMap(r)
+		if err != nil {
+			return nil, err
+		}
+		out.Items = append(out.Items, item)
+	}
+	return out, nil
+}
+
+// fakeLauncher records terminate calls and may inject an error.
+type fakeLauncher struct {
+	terminated   []string
+	terminateErr error
+}
+
+func (f *fakeLauncher) Terminate(_ context.Context, ids ...string) error {
+	f.terminated = append(f.terminated, ids...)
+	return f.terminateErr
+}
+
+// fakeGitHub records DeregisterRunner calls and may inject an error.
+type fakeGitHub struct {
+	calls []deregCall
+	err   error
+}
+
+type deregCall struct {
+	repo     string
+	runnerID int64
+}
+
+func (f *fakeGitHub) DeregisterRunner(_ context.Context, repo string, runnerID int64) error {
+	f.calls = append(f.calls, deregCall{repo: repo, runnerID: runnerID})
+	return f.err
+}
+
+// fakePub records published ScaleUp messages and may inject an error.
+type fakePub struct {
+	msgs []*sqs.ScaleUpMessage
+	err  error
+}
+
+func (f *fakePub) Publish(_ context.Context, m *sqs.ScaleUpMessage) error {
+	f.msgs = append(f.msgs, m)
+	return f.err
+}
+
+// helpers ---------------------------------------------------------------
+
+// fixedNow returns a Time provider that always yields t.
+func fixedNow(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+// stalePendingRecord builds a status=pending record whose CreatedAt is
+// staleAfter*2 ago so it is well past the cutoff.
+func stalePendingRecord(now time.Time, attempts int) *Record {
+	return &Record{
+		RunnerID:          "owner/repo#1",
+		InstanceID:        "i-pending",
+		JobID:             1,
+		RunID:             10,
+		Repository:        "owner/repo",
+		Labels:            []string{"self-hosted", "linux"},
+		Status:            StatusPending,
+		CreatedAt:         now.Add(-2 * time.Hour).Unix(),
+		UpdatedAt:         now.Add(-2 * time.Hour).Unix(),
+		TTL:               now.Add(24 * time.Hour).Unix(),
+		GitHubRunnerID:    99,
+		ReEnqueueAttempts: attempts,
+	}
+}
+
+// staleRunningRecord builds a status=running record whose CreatedAt is far
+// past MaxAge.
+func staleRunningRecord(now time.Time, attempts int) *Record {
+	return &Record{
+		RunnerID:          "owner/repo#2",
+		InstanceID:        "i-running",
+		JobID:             2,
+		RunID:             20,
+		Repository:        "owner/repo",
+		Labels:            []string{"self-hosted", "linux"},
+		Status:            StatusRunning,
+		CreatedAt:         now.Add(-12 * time.Hour).Unix(),
+		UpdatedAt:         now.Add(-12 * time.Hour).Unix(),
+		TTL:               now.Add(24 * time.Hour).Unix(),
+		GitHubRunnerID:    77,
+		ReEnqueueAttempts: attempts,
+	}
+}
+
+// updateContains returns true if the captured update's expression
+// referenced the named attribute (as set by Store.Update).
+func updateContains(u capturedUpdate, attrName string) bool {
+	// Store.Update emits ":s" -> status, ":i" -> instance_id, ":g" -> gh_runner_id,
+	// ":r" -> re_enqueue_attempts, ":l" -> last_attempt_at, ":u" -> updated_at.
+	want := ""
+	switch attrName {
+	case "status":
+		want = ":s"
+	case "instance_id":
+		want = ":i"
+	case "gh_runner_id":
+		want = ":g"
+	case "re_enqueue_attempts":
+		want = ":r"
+	case "last_attempt_at":
+		want = ":l"
+	case "updated_at":
+		want = ":u"
+	default:
+		return false
+	}
+	_, ok := u.values[want]
+	return ok
+}
+
+// updateStringValue returns the string of the named attribute in the
+// captured update, or "" if absent.
+func updateStringValue(u capturedUpdate, attrName string) string {
+	want := ""
+	switch attrName {
+	case "status":
+		want = ":s"
+	case "instance_id":
+		want = ":i"
+	}
+	v, ok := u.values[want].(*types.AttributeValueMemberS)
+	if !ok {
+		return ""
+	}
+	return v.Value
+}
+
+// updateIntValue returns the integer of the named numeric attribute in
+// the captured update, or -1 if absent.
+func updateIntValue(u capturedUpdate, attrName string) int64 {
+	want := ""
+	switch attrName {
+	case "gh_runner_id":
+		want = ":g"
+	case "re_enqueue_attempts":
+		want = ":r"
+	case "last_attempt_at":
+		want = ":l"
+	}
+	v, ok := u.values[want].(*types.AttributeValueMemberN)
+	if !ok {
+		return -1
+	}
+	n, err := strconv.ParseInt(v.Value, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// builds wires a Cleaner with sane test defaults backed by the supplied
+// fakes. now is fixed so cutoff arithmetic is deterministic.
+func newTestCleaner(t *testing.T, ddb DynamoDBAPI, ec2 EC2Terminator, gh ghClient, pub scaleupPublisher, maxAttempts int, now time.Time) *Cleaner {
+	t.Helper()
+	store := NewStore(ddb, "t")
+	return &Cleaner{
+		Store:                store,
+		Launcher:             ec2,
+		GitHub:               gh,
+		ScaleUpPublisher:     pub,
+		StaleAfter:           10 * time.Minute,
+		MaxAge:               6 * time.Hour,
+		MaxReEnqueueAttempts: maxAttempts,
+		Now:                  fixedNow(now),
+	}
+}
+
+// tests -----------------------------------------------------------------
+
+func TestCleaner_StalePending_UnderBudget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 0)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := []string{rec.InstanceID}; len(ec2.terminated) != 1 || ec2.terminated[0] != got[0] {
+		t.Errorf("terminated = %v, want %v", ec2.terminated, got)
+	}
+	if len(gh.calls) != 1 || gh.calls[0].runnerID != rec.GitHubRunnerID {
+		t.Errorf("deregister calls = %+v, want one call with runnerID=%d", gh.calls, rec.GitHubRunnerID)
+	}
+	if len(pub.msgs) != 1 {
+		t.Fatalf("expected 1 republish, got %d", len(pub.msgs))
+	}
+	if got := pub.msgs[0].ReEnqueueAttempts; got != 1 {
+		t.Errorf("republished ReEnqueueAttempts = %d, want 1", got)
+	}
+	if pub.msgs[0].JobID != rec.JobID || pub.msgs[0].RepositoryFull != rec.Repository {
+		t.Errorf("republished message body mismatch: %+v", pub.msgs[0])
+	}
+	if len(ddb.updates) != 1 {
+		t.Fatalf("expected 1 DDB update, got %d", len(ddb.updates))
+	}
+	u := ddb.updates[0]
+	if got := updateStringValue(u, "status"); got != StatusFailed {
+		t.Errorf("update status = %q, want failed", got)
+	}
+	if got := updateIntValue(u, "re_enqueue_attempts"); got != 1 {
+		t.Errorf("update re_enqueue_attempts = %d, want 1", got)
+	}
+	if !updateContains(u, "last_attempt_at") {
+		t.Error("update should set last_attempt_at")
+	}
+	if res.Stale != 1 || res.Orphans != 1 || res.Errors != 0 {
+		t.Errorf("result = %+v, want stale=1 orphans=1 errors=0", res)
+	}
+}
+
+func TestCleaner_StalePending_AtBudget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 2)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(ec2.terminated) != 1 || len(gh.calls) != 1 {
+		t.Errorf("expected 1 terminate + 1 deregister, got terminated=%v deregister=%+v", ec2.terminated, gh.calls)
+	}
+	if len(pub.msgs) != 1 {
+		t.Fatalf("expected 1 republish, got %d", len(pub.msgs))
+	}
+	if got := pub.msgs[0].ReEnqueueAttempts; got != 3 {
+		t.Errorf("republished ReEnqueueAttempts = %d, want 3", got)
+	}
+	if len(ddb.updates) != 1 {
+		t.Fatalf("expected 1 update, got %d", len(ddb.updates))
+	}
+	if got := updateIntValue(ddb.updates[0], "re_enqueue_attempts"); got != 3 {
+		t.Errorf("update re_enqueue_attempts = %d, want 3", got)
+	}
+	if res.Stale != 1 || res.Orphans != 1 || res.Errors != 0 {
+		t.Errorf("result = %+v, want stale=1 orphans=1 errors=0", res)
+	}
+}
+
+func TestCleaner_StalePending_Exhausted(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 3)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(ec2.terminated) != 1 || len(gh.calls) != 1 {
+		t.Errorf("expected 1 terminate + 1 deregister, got terminated=%v deregister=%+v", ec2.terminated, gh.calls)
+	}
+	if len(pub.msgs) != 0 {
+		t.Errorf("expected NO republish, got %+v", pub.msgs)
+	}
+	if len(ddb.updates) != 1 {
+		t.Fatalf("expected 1 terminal-failed update, got %d", len(ddb.updates))
+	}
+	if got := updateStringValue(ddb.updates[0], "status"); got != StatusFailed {
+		t.Errorf("update status = %q, want failed", got)
+	}
+	if updateContains(ddb.updates[0], "re_enqueue_attempts") {
+		t.Error("exhausted-budget update should NOT bump re_enqueue_attempts")
+	}
+	if res.Stale != 1 || res.Orphans != 1 || res.Errors != 0 {
+		t.Errorf("result = %+v, want stale=1 orphans=1 errors=0", res)
+	}
+}
+
+func TestCleaner_StaleRunning_NeverReenqueues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// Even with attempts=0 (well under budget) a running record must NOT
+	// be re-enqueued — the job may already be considered done by GitHub.
+	rec := staleRunningRecord(now, 0)
+	ddb := &scanFakeDDB{running: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(ec2.terminated) != 1 || ec2.terminated[0] != rec.InstanceID {
+		t.Errorf("terminated = %v, want %s", ec2.terminated, rec.InstanceID)
+	}
+	if len(gh.calls) != 1 || gh.calls[0].runnerID != rec.GitHubRunnerID {
+		t.Errorf("deregister calls = %+v, want one with runnerID=%d", gh.calls, rec.GitHubRunnerID)
+	}
+	if len(pub.msgs) != 0 {
+		t.Fatalf("stale-running MUST NOT re-enqueue, got %+v", pub.msgs)
+	}
+	if len(ddb.updates) != 1 {
+		t.Fatalf("expected 1 update marking failed, got %d", len(ddb.updates))
+	}
+	if got := updateStringValue(ddb.updates[0], "status"); got != StatusFailed {
+		t.Errorf("update status = %q, want failed", got)
+	}
+	if res.Stale != 1 || res.Orphans != 0 || res.Errors != 0 {
+		t.Errorf("result = %+v, want stale=1 orphans=0 errors=0", res)
+	}
+}
+
+func TestCleaner_StaleRunning_NeverReenqueues_EvenWithAttemptsZero(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// Sanity duplicate guard: reordering attempts shouldn't change the
+	// outcome for the running path.
+	rec := staleRunningRecord(now, 5)
+	ddb := &scanFakeDDB{running: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 99, now) // huge budget
+
+	if _, err := c.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(pub.msgs) != 0 {
+		t.Fatalf("stale-running MUST NOT re-enqueue regardless of budget, got %+v", pub.msgs)
+	}
+}
+
+func TestCleaner_Deregister404_DoesNotBlockUpdate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 0)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	// *github.Client.DeregisterRunner already maps 404 -> nil, so a fake
+	// returning nil mirrors the contract.
+	gh := &fakeGitHub{err: nil}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	if _, err := c.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(ddb.updates) != 1 {
+		t.Fatalf("expected DDB update even when deregister is a no-op, got %d updates", len(ddb.updates))
+	}
+}
+
+func TestCleaner_DeregisterNon404_DoesNotBlockUpdate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 0)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{err: errors.New("github: 500 internal server error")}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	if _, err := c.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gh.calls) != 1 {
+		t.Errorf("expected 1 deregister attempt, got %d", len(gh.calls))
+	}
+	if len(pub.msgs) != 1 {
+		t.Errorf("expected republish to proceed, got %d", len(pub.msgs))
+	}
+	if len(ddb.updates) != 1 {
+		t.Errorf("expected DDB update to proceed despite deregister error, got %d", len(ddb.updates))
+	}
+}
+
+func TestCleaner_PublishError_NoUpdate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 0)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{err: errors.New("sqs: publish failed")}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(ec2.terminated) != 1 || len(gh.calls) != 1 {
+		t.Errorf("terminate + deregister should still happen before publish")
+	}
+	if len(ddb.updates) != 0 {
+		t.Errorf("expected NO DDB update on publish failure, got %+v", ddb.updates)
+	}
+	if res.Errors == 0 {
+		t.Errorf("result.Errors should be incremented on publish error: %+v", res)
+	}
+}
+
+func TestCleaner_TerminateError_SkipsRecord(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	rec := stalePendingRecord(now, 0)
+	ddb := &scanFakeDDB{pending: []*Record{rec}}
+	ec2 := &fakeLauncher{terminateErr: errors.New("ec2: throttled")}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(gh.calls) != 0 || len(pub.msgs) != 0 || len(ddb.updates) != 0 {
+		t.Errorf("after terminate failure no further side-effects should occur (deregister=%d publish=%d update=%d)",
+			len(gh.calls), len(pub.msgs), len(ddb.updates))
+	}
+	if res.Errors != 1 || res.Stale != 0 || res.Orphans != 0 {
+		t.Errorf("result = %+v, want errors=1 stale=0 orphans=0", res)
+	}
+}
+
+func TestCleaner_MultipleRecords_Aggregates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	under := stalePendingRecord(now, 0)
+	under.RunnerID = "owner/repo#1"
+	under.JobID = 1
+	under.GitHubRunnerID = 91
+	under.InstanceID = "i-under"
+
+	at := stalePendingRecord(now, 2)
+	at.RunnerID = "owner/repo#2"
+	at.JobID = 2
+	at.GitHubRunnerID = 92
+	at.InstanceID = "i-at"
+
+	exhausted := stalePendingRecord(now, 3)
+	exhausted.RunnerID = "owner/repo#3"
+	exhausted.JobID = 3
+	exhausted.GitHubRunnerID = 93
+	exhausted.InstanceID = "i-exhausted"
+
+	ddb := &scanFakeDDB{pending: []*Record{under, at, exhausted}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(ec2.terminated) != 3 {
+		t.Errorf("terminated %d instances, want 3 (%v)", len(ec2.terminated), ec2.terminated)
+	}
+	if len(gh.calls) != 3 {
+		t.Errorf("deregistered %d runners, want 3", len(gh.calls))
+	}
+	// Two republishes (under-budget + at-budget); exhausted record skips publish.
+	if len(pub.msgs) != 2 {
+		t.Fatalf("republished %d messages, want 2", len(pub.msgs))
+	}
+	if len(ddb.updates) != 3 {
+		t.Errorf("DDB updates %d, want 3", len(ddb.updates))
+	}
+	if res.Stale != 3 || res.Orphans != 3 || res.Errors != 0 {
+		t.Errorf("result = %+v, want stale=3 orphans=3 errors=0", res)
+	}
+
+	// All updates land on the terminal failed status.
+	for _, u := range ddb.updates {
+		if got := updateStringValue(u, "status"); got != StatusFailed {
+			t.Errorf("update %s status = %q, want failed", u.id, got)
+		}
+	}
+}
+
+func TestCleaner_RecordTooFresh_Skipped(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	fresh := stalePendingRecord(now, 0)
+	// Override CreatedAt so the record is well WITHIN the StaleAfter window.
+	fresh.CreatedAt = now.Add(-1 * time.Minute).Unix()
+	ddb := &scanFakeDDB{pending: []*Record{fresh}}
+	ec2 := &fakeLauncher{}
+	gh := &fakeGitHub{}
+	pub := &fakePub{}
+	c := newTestCleaner(t, ddb, ec2, gh, pub, 3, now)
+
+	res, err := c.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(ec2.terminated) != 0 || len(gh.calls) != 0 || len(pub.msgs) != 0 || len(ddb.updates) != 0 {
+		t.Errorf("fresh record should be a no-op; got terminate=%v dereg=%v publish=%v update=%v",
+			ec2.terminated, gh.calls, pub.msgs, ddb.updates)
+	}
+	if res.Stale != 0 || res.Orphans != 0 || res.Errors != 0 {
+		t.Errorf("result = %+v, want zero", res)
+	}
+}
+
+// stateTypeAlignmentSentinel is a compile-time assertion that the local
+// scaleupPublisher interface remains compatible with state.RunnerUpdate
+// usage in cleanup.go. It exists only to surface signature drift early.
+var _ = state.RunnerUpdate{}

--- a/lambda/internal/runner/state.go
+++ b/lambda/internal/runner/state.go
@@ -69,7 +69,7 @@ func (s *Store) Get(ctx context.Context, repository string, jobID int64) (*Recor
 		return nil, fmt.Errorf("get runner record: %w", err)
 	}
 	if out.Item == nil {
-		return nil, nil
+		return nil, state.ErrNotFound
 	}
 	var record Record
 	if err := attributevalue.UnmarshalMap(out.Item, &record); err != nil {

--- a/lambda/internal/runner/state.go
+++ b/lambda/internal/runner/state.go
@@ -120,6 +120,9 @@ func (s *Store) Update(ctx context.Context, id string, u state.RunnerUpdate) err
 	if u.Status != nil {
 		add("status", "s", &types.AttributeValueMemberS{Value: *u.Status})
 	}
+	if u.InstanceID != nil {
+		add("instance_id", "i", &types.AttributeValueMemberS{Value: *u.InstanceID})
+	}
 	if u.GitHubRunnerID != nil {
 		add("gh_runner_id", "g", &types.AttributeValueMemberN{Value: strconv.FormatInt(*u.GitHubRunnerID, 10)})
 	}

--- a/lambda/internal/runner/state.go
+++ b/lambda/internal/runner/state.go
@@ -58,7 +58,15 @@ func (s *Store) Put(ctx context.Context, record *Record) error {
 
 // Get retrieves a runner record by repository and job ID.
 func (s *Store) Get(ctx context.Context, repository string, jobID int64) (*Record, error) {
-	id := runnerID(repository, jobID)
+	return s.GetByID(ctx, runnerID(repository, jobID))
+}
+
+// GetByID retrieves a runner record by its composite primary key
+// ("<repository>#<jobID>"). It is the single-argument variant used by
+// adapters (e.g. StateAdapter) that hold a key produced elsewhere in the
+// pipeline (the lifecycle handler does this) without needing to split it
+// back into its components.
+func (s *Store) GetByID(ctx context.Context, id string) (*Record, error) {
 	out, err := s.client.GetItem(ctx, &dynamodb.GetItemInput{
 		TableName: aws.String(s.tableName),
 		Key: map[string]types.AttributeValue{

--- a/lambda/internal/runner/state.go
+++ b/lambda/internal/runner/state.go
@@ -3,12 +3,16 @@ package runner
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
 
 // DynamoDBAPI abstracts the DynamoDB operations for testing.
@@ -95,6 +99,55 @@ func (s *Store) UpdateStatus(ctx context.Context, repository string, jobID int64
 	})
 	if err != nil {
 		return fmt.Errorf("update runner status: %w", err)
+	}
+	return nil
+}
+
+// Update applies a partial update to a runner record by composite ID.
+// Only non-nil fields in u are written. UpdatedAt is always bumped to the
+// current Unix time. If u carries no field changes, this is a no-op.
+func (s *Store) Update(ctx context.Context, id string, u state.RunnerUpdate) error {
+	exprs := []string{}
+	names := map[string]string{}
+	values := map[string]types.AttributeValue{}
+
+	add := func(attrName, exprName string, v types.AttributeValue) {
+		exprs = append(exprs, fmt.Sprintf("#%s = :%s", exprName, exprName))
+		names["#"+exprName] = attrName
+		values[":"+exprName] = v
+	}
+
+	if u.Status != nil {
+		add("status", "s", &types.AttributeValueMemberS{Value: *u.Status})
+	}
+	if u.GitHubRunnerID != nil {
+		add("gh_runner_id", "g", &types.AttributeValueMemberN{Value: strconv.FormatInt(*u.GitHubRunnerID, 10)})
+	}
+	if u.ReEnqueueAttempts != nil {
+		add("re_enqueue_attempts", "r", &types.AttributeValueMemberN{Value: strconv.Itoa(*u.ReEnqueueAttempts)})
+	}
+	if u.LastAttemptAt != nil {
+		add("last_attempt_at", "l", &types.AttributeValueMemberN{Value: strconv.FormatInt(u.LastAttemptAt.Unix(), 10)})
+	}
+	// Always bump updated_at so the live record reflects the write.
+	add("updated_at", "u", &types.AttributeValueMemberN{Value: strconv.FormatInt(time.Now().Unix(), 10)})
+
+	if len(exprs) == 1 {
+		// Only updated_at would change — caller didn't specify any field. Treat as no-op.
+		return nil
+	}
+
+	_, err := s.client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"runner_id": &types.AttributeValueMemberS{Value: id},
+		},
+		UpdateExpression:          aws.String("SET " + strings.Join(exprs, ", ")),
+		ExpressionAttributeNames:  names,
+		ExpressionAttributeValues: values,
+	})
+	if err != nil {
+		return fmt.Errorf("dynamo: Update %s: %w", id, err)
 	}
 	return nil
 }

--- a/lambda/internal/runner/state_adapter.go
+++ b/lambda/internal/runner/state_adapter.go
@@ -1,0 +1,98 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// StateAdapter wraps *Store to satisfy a subset of state.RunnerStore for the
+// lifecycle handler. Only Get and Update are implemented; Put/List/Delete
+// panic. This is a temporary bridge until the dynamo Store is refactored to
+// operate on state.Runner directly (planned for #45's cloud-abstraction work).
+//
+// The adapter exists because the lifecycle handler is written against the
+// cloud-agnostic state.RunnerStore contract, while the rest of the codebase
+// (scaleup, scaledown) consumes *Store directly. Mirroring scaleup's
+// construction in cmd/lifecycle/main.go would otherwise require two
+// independent DDB layers; instead we reuse *Store and translate at the edge.
+type StateAdapter struct {
+	Inner *Store
+}
+
+// NewStateAdapter builds an adapter that delegates to the given Store.
+func NewStateAdapter(inner *Store) *StateAdapter {
+	return &StateAdapter{Inner: inner}
+}
+
+// Get fetches a record by composite ID and converts the DDB *Record into a
+// state.Runner. Returns state.ErrNotFound when no record exists (inherited
+// from *Store.GetByID).
+func (a *StateAdapter) Get(ctx context.Context, id string) (state.Runner, error) {
+	rec, err := a.Inner.GetByID(ctx, id)
+	if err != nil {
+		return state.Runner{}, err
+	}
+	return recordToRunner(rec), nil
+}
+
+// Update delegates to *Store.Update without translation: state.RunnerUpdate
+// is the canonical update payload that *Store already speaks.
+func (a *StateAdapter) Update(ctx context.Context, id string, u state.RunnerUpdate) error {
+	return a.Inner.Update(ctx, id, u)
+}
+
+// Put is intentionally unimplemented. The lifecycle handler never writes new
+// records; scaleup is the sole writer, and it uses *Store.Put directly with
+// the *Record shape. Calling this is a programmer error.
+func (a *StateAdapter) Put(_ context.Context, _ state.Runner) error {
+	panic("runner.StateAdapter.Put: not implemented — use *Store.Put with *Record")
+}
+
+// List is intentionally unimplemented. The lifecycle handler queries by
+// composite ID via Get; scaledown's sweep uses *Store.ListByStatus directly.
+func (a *StateAdapter) List(_ context.Context, _ state.Filter) ([]state.Runner, error) {
+	panic("runner.StateAdapter.List: not implemented — use *Store.ListByStatus")
+}
+
+// Delete is intentionally unimplemented. The lifecycle pipeline marks
+// records via status transitions (completed/failed); hard deletes rely on
+// DynamoDB TTL.
+func (a *StateAdapter) Delete(_ context.Context, _ string) error {
+	panic("runner.StateAdapter.Delete: not implemented — TTL handles record lifetime")
+}
+
+// recordToRunner converts a *Record (DDB shape, with Unix int64 timestamps)
+// into a state.Runner (cloud-agnostic shape, with time.Time timestamps).
+// Zero-valued int64 timestamps become zero-valued time.Time values so callers
+// can branch on time.Time.IsZero() without special-casing.
+func recordToRunner(r *Record) state.Runner {
+	if r == nil {
+		return state.Runner{}
+	}
+	return state.Runner{
+		ID:                r.RunnerID,
+		InstanceID:        r.InstanceID,
+		Repository:        r.Repository,
+		Labels:            r.Labels,
+		Status:            r.Status,
+		LaunchedAt:        unixToTime(r.CreatedAt),
+		UpdatedAt:         unixToTime(r.UpdatedAt),
+		TTL:               unixToTime(r.TTL),
+		GitHubRunnerID:    r.GitHubRunnerID,
+		ReEnqueueAttempts: r.ReEnqueueAttempts,
+		LastAttemptAt:     unixToTime(r.LastAttemptAt),
+	}
+}
+
+// unixToTime converts a Unix-second int64 to a time.Time, mapping zero to a
+// zero-valued time.Time so IsZero() works as expected. Non-zero values use
+// time.Unix on the seconds component (records do not store sub-second
+// precision).
+func unixToTime(secs int64) time.Time {
+	if secs == 0 {
+		return time.Time{}
+	}
+	return time.Unix(secs, 0)
+}

--- a/lambda/internal/runner/state_adapter_test.go
+++ b/lambda/internal/runner/state_adapter_test.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// Compile-time assertion that StateAdapter satisfies state.RunnerStore.
+var _ state.RunnerStore = (*StateAdapter)(nil)
+
+func TestStateAdapter_GetTranslatesRecordToRunner(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC).Unix()
+	rec := &Record{
+		RunnerID:          "owner/repo#1",
+		InstanceID:        "i-abc",
+		JobID:             1,
+		RunID:             2,
+		Repository:        "owner/repo",
+		Labels:            []string{"self-hosted", "linux"},
+		Status:            StatusRunning,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		TTL:               now + 3600,
+		GitHubRunnerID:    99,
+		ReEnqueueAttempts: 1,
+		LastAttemptAt:     now,
+	}
+
+	fake := &fakeDDBClient{}
+	store := NewStore(fake, "t")
+	if err := store.Put(context.Background(), rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	adapter := NewStateAdapter(store)
+
+	got, err := adapter.Get(context.Background(), "owner/repo#1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != "owner/repo#1" {
+		t.Errorf("ID = %q want owner/repo#1", got.ID)
+	}
+	if got.Status != StatusRunning {
+		t.Errorf("Status = %q want %q", got.Status, StatusRunning)
+	}
+	if got.GitHubRunnerID != 99 {
+		t.Errorf("GitHubRunnerID = %d want 99", got.GitHubRunnerID)
+	}
+	if got.ReEnqueueAttempts != 1 {
+		t.Errorf("ReEnqueueAttempts = %d want 1", got.ReEnqueueAttempts)
+	}
+	if got.LaunchedAt.Unix() != now {
+		t.Errorf("LaunchedAt = %d want %d", got.LaunchedAt.Unix(), now)
+	}
+	if got.LastAttemptAt.Unix() != now {
+		t.Errorf("LastAttemptAt = %d want %d", got.LastAttemptAt.Unix(), now)
+	}
+}
+
+func TestStateAdapter_GetNotFound(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeDDBClient{}
+	store := NewStore(fake, "t")
+	adapter := NewStateAdapter(store)
+
+	_, err := adapter.Get(context.Background(), "owner/repo#999")
+	if !errors.Is(err, state.ErrNotFound) {
+		t.Errorf("expected state.ErrNotFound, got %v", err)
+	}
+}
+
+func TestStateAdapter_UpdateDelegates(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeDDBClient{}
+	store := NewStore(fake, "t")
+	adapter := NewStateAdapter(store)
+
+	status := state.StatusCompleted
+	if err := adapter.Update(context.Background(), "owner/repo#1", state.RunnerUpdate{
+		Status: &status,
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if fake.updateCalls != 1 {
+		t.Errorf("expected 1 UpdateItem call, got %d", fake.updateCalls)
+	}
+}
+
+func TestRecordToRunner_NilReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	got := recordToRunner(nil)
+	if got.ID != "" || got.InstanceID != "" || got.Status != "" || got.GitHubRunnerID != 0 || len(got.Labels) != 0 {
+		t.Errorf("expected zero-valued Runner, got %+v", got)
+	}
+	if !got.LaunchedAt.IsZero() || !got.UpdatedAt.IsZero() || !got.TTL.IsZero() || !got.LastAttemptAt.IsZero() {
+		t.Errorf("expected zero timestamps, got %+v", got)
+	}
+}
+
+func TestRecordToRunner_ZeroTimestampsRemainZero(t *testing.T) {
+	t.Parallel()
+
+	rec := &Record{
+		RunnerID: "owner/repo#1",
+		// CreatedAt, UpdatedAt, TTL, LastAttemptAt all zero.
+	}
+	got := recordToRunner(rec)
+	if !got.LaunchedAt.IsZero() {
+		t.Errorf("LaunchedAt should be zero time, got %v", got.LaunchedAt)
+	}
+	if !got.UpdatedAt.IsZero() {
+		t.Errorf("UpdatedAt should be zero time, got %v", got.UpdatedAt)
+	}
+	if !got.TTL.IsZero() {
+		t.Errorf("TTL should be zero time, got %v", got.TTL)
+	}
+	if !got.LastAttemptAt.IsZero() {
+		t.Errorf("LastAttemptAt should be zero time, got %v", got.LastAttemptAt)
+	}
+}
+
+func TestStateAdapter_PutPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic")
+		}
+	}()
+	adapter := NewStateAdapter(nil)
+	_ = adapter.Put(context.Background(), state.Runner{})
+}
+
+func TestStateAdapter_ListPanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic")
+		}
+	}()
+	adapter := NewStateAdapter(nil)
+	_, _ = adapter.List(context.Background(), state.Filter{})
+}
+
+func TestStateAdapter_DeletePanics(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic")
+		}
+	}()
+	adapter := NewStateAdapter(nil)
+	_ = adapter.Delete(context.Background(), "owner/repo#1")
+}

--- a/lambda/internal/runner/state_test.go
+++ b/lambda/internal/runner/state_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -217,6 +218,21 @@ func TestStore_PutGet_LegacyRecordWithoutNewFields(t *testing.T) {
 	}
 	if _, present := item["last_attempt_at"]; present {
 		t.Error("last_attempt_at should be omitted when zero")
+	}
+}
+
+func TestStore_Get_NotFoundReturnsStateErrNotFound(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeDDBClient{}
+	s := NewStore(fake, "t")
+
+	got, err := s.Get(context.Background(), "owner/repo", 999)
+	if got != nil {
+		t.Errorf("expected nil record, got %+v", got)
+	}
+	if !errors.Is(err, state.ErrNotFound) {
+		t.Errorf("expected state.ErrNotFound, got %v", err)
 	}
 }
 

--- a/lambda/internal/runner/state_test.go
+++ b/lambda/internal/runner/state_test.go
@@ -1,0 +1,226 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// fakeDDBClient is an in-memory stand-in for the DynamoDB API used by Store.
+type fakeDDBClient struct {
+	putCalls        int
+	updateCalls     int
+	getCalls        int
+	scanCalls       int
+	lastUpdateNames map[string]bool
+	lastUpdateExpr  string
+	// items keyed by runner_id holds the last marshalled Put payload so Get
+	// can return it for round-trip assertions.
+	items map[string]map[string]types.AttributeValue
+}
+
+func (f *fakeDDBClient) PutItem(_ context.Context, input *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
+	f.putCalls++
+	if f.items == nil {
+		f.items = map[string]map[string]types.AttributeValue{}
+	}
+	if rid, ok := input.Item["runner_id"].(*types.AttributeValueMemberS); ok {
+		f.items[rid.Value] = input.Item
+	}
+	return &dynamodb.PutItemOutput{}, nil
+}
+
+func (f *fakeDDBClient) GetItem(_ context.Context, input *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	f.getCalls++
+	if f.items == nil {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	rid, ok := input.Key["runner_id"].(*types.AttributeValueMemberS)
+	if !ok {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	item, ok := f.items[rid.Value]
+	if !ok {
+		return &dynamodb.GetItemOutput{}, nil
+	}
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func (f *fakeDDBClient) UpdateItem(_ context.Context, in *dynamodb.UpdateItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error) {
+	f.updateCalls++
+	if f.lastUpdateNames == nil {
+		f.lastUpdateNames = map[string]bool{}
+	}
+	for _, name := range in.ExpressionAttributeNames {
+		f.lastUpdateNames[name] = true
+	}
+	if in.UpdateExpression != nil {
+		f.lastUpdateExpr = *in.UpdateExpression
+	}
+	return &dynamodb.UpdateItemOutput{}, nil
+}
+
+func (f *fakeDDBClient) Scan(_ context.Context, _ *dynamodb.ScanInput, _ ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	f.scanCalls++
+	return &dynamodb.ScanOutput{}, nil
+}
+
+func TestStore_Update_PartialFields(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		update      state.RunnerUpdate
+		wantAttrSet []string
+		wantNoOp    bool
+	}{
+		{
+			name:     "no fields = no-op",
+			update:   state.RunnerUpdate{},
+			wantNoOp: true,
+		},
+		{
+			name:        "only status",
+			update:      state.RunnerUpdate{Status: stringPtr(state.StatusRunning)},
+			wantAttrSet: []string{"status", "updated_at"},
+		},
+		{
+			name: "all four fields",
+			update: state.RunnerUpdate{
+				Status:            stringPtr(state.StatusFailed),
+				GitHubRunnerID:    int64Ptr(99),
+				ReEnqueueAttempts: intPtr(2),
+				LastAttemptAt:     timePtr(time.Unix(1714564800, 0)),
+			},
+			wantAttrSet: []string{"status", "gh_runner_id", "re_enqueue_attempts", "last_attempt_at", "updated_at"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeDDBClient{}
+			s := NewStore(fake, "t")
+			if err := s.Update(context.Background(), "r1", tc.update); err != nil {
+				t.Fatalf("Update: %v", err)
+			}
+			if tc.wantNoOp {
+				if fake.updateCalls != 0 {
+					t.Fatalf("expected no UpdateItem calls, got %d", fake.updateCalls)
+				}
+				return
+			}
+			if fake.updateCalls != 1 {
+				t.Fatalf("expected 1 UpdateItem call, got %d", fake.updateCalls)
+			}
+			for _, attr := range tc.wantAttrSet {
+				if !fake.lastUpdateNames[attr] {
+					t.Errorf("expected UpdateExpression to set %q; saw names=%v", attr, fake.lastUpdateNames)
+				}
+			}
+		})
+	}
+}
+
+func TestStore_PutGet_RoundTripsNewFields(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC).Unix()
+	rec := &Record{
+		RunnerID:          "owner/repo#123",
+		InstanceID:        "i-1",
+		JobID:             123,
+		RunID:             456,
+		Repository:        "owner/repo",
+		Labels:            []string{"self-hosted", "linux"},
+		Status:            StatusPending,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		TTL:               now + 3600,
+		GitHubRunnerID:    42,
+		ReEnqueueAttempts: 1,
+		LastAttemptAt:     now,
+	}
+	fake := &fakeDDBClient{}
+	s := NewStore(fake, "t")
+
+	if err := s.Put(context.Background(), rec); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := s.Get(context.Background(), "owner/repo", 123)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil record")
+	}
+	if got.GitHubRunnerID != 42 {
+		t.Errorf("GitHubRunnerID = %d, want 42", got.GitHubRunnerID)
+	}
+	if got.ReEnqueueAttempts != 1 {
+		t.Errorf("ReEnqueueAttempts = %d, want 1", got.ReEnqueueAttempts)
+	}
+	if got.LastAttemptAt != now {
+		t.Errorf("LastAttemptAt = %d, want %d", got.LastAttemptAt, now)
+	}
+}
+
+func TestStore_PutGet_LegacyRecordWithoutNewFields(t *testing.T) {
+	t.Parallel()
+
+	// Simulates a legacy DDB record that predates the new lifecycle fields.
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC).Unix()
+	legacy := map[string]types.AttributeValue{
+		"runner_id":   &types.AttributeValueMemberS{Value: "owner/repo#1"},
+		"instance_id": &types.AttributeValueMemberS{Value: "i-legacy"},
+		"job_id":      &types.AttributeValueMemberN{Value: "1"},
+		"run_id":      &types.AttributeValueMemberN{Value: "2"},
+		"repository":  &types.AttributeValueMemberS{Value: "owner/repo"},
+		"status":      &types.AttributeValueMemberS{Value: StatusPending},
+		"created_at":  &types.AttributeValueMemberN{Value: itoa(now)},
+		"updated_at":  &types.AttributeValueMemberN{Value: itoa(now)},
+		"ttl":         &types.AttributeValueMemberN{Value: itoa(now + 3600)},
+	}
+	fake := &fakeDDBClient{items: map[string]map[string]types.AttributeValue{
+		"owner/repo#1": legacy,
+	}}
+	s := NewStore(fake, "t")
+
+	got, err := s.Get(context.Background(), "owner/repo", 1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil record")
+	}
+	if got.GitHubRunnerID != 0 || got.ReEnqueueAttempts != 0 || got.LastAttemptAt != 0 {
+		t.Errorf("legacy record should have zero new fields, got %+v", got)
+	}
+
+	// Sanity: round-trip via marshal to confirm omitempty does not write zero values.
+	item, err := attributevalue.MarshalMap(got)
+	if err != nil {
+		t.Fatalf("MarshalMap: %v", err)
+	}
+	if _, present := item["gh_runner_id"]; present {
+		t.Error("gh_runner_id should be omitted when zero")
+	}
+	if _, present := item["re_enqueue_attempts"]; present {
+		t.Error("re_enqueue_attempts should be omitted when zero")
+	}
+	if _, present := item["last_attempt_at"]; present {
+		t.Error("last_attempt_at should be omitted when zero")
+	}
+}
+
+func stringPtr(s string) *string     { return &s }
+func int64Ptr(i int64) *int64        { return &i }
+func intPtr(i int) *int              { return &i }
+func timePtr(t time.Time) *time.Time { return &t }

--- a/lambda/internal/runner/types.go
+++ b/lambda/internal/runner/types.go
@@ -1,13 +1,24 @@
 package runner
 
-import "time"
+import (
+	"time"
 
-// Status constants for runner records.
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// Runner is an alias for state.Runner. The lifecycle work uses
+// state.RunnerStore directly; aliasing here keeps callers that import
+// runner.Runner working without modification (Go type aliases are transparent).
+// New code should prefer state.Runner.
+type Runner = state.Runner
+
+// Status constants are re-exported from the canonical state package so
+// callers that historically used runner.Status* keep compiling.
 const (
-	StatusPending   = "pending"
-	StatusRunning   = "running"
-	StatusCompleted = "completed"
-	StatusFailed    = "failed"
+	StatusPending   = state.StatusPending
+	StatusRunning   = state.StatusRunning
+	StatusCompleted = state.StatusCompleted
+	StatusFailed    = state.StatusFailed
 )
 
 // Record is the DynamoDB state record for an active runner.

--- a/lambda/internal/runner/types.go
+++ b/lambda/internal/runner/types.go
@@ -12,16 +12,19 @@ const (
 
 // Record is the DynamoDB state record for an active runner.
 type Record struct {
-	RunnerID   string   `dynamodbav:"runner_id"`
-	InstanceID string   `dynamodbav:"instance_id"`
-	JobID      int64    `dynamodbav:"job_id"`
-	RunID      int64    `dynamodbav:"run_id"`
-	Repository string   `dynamodbav:"repository"`
-	Labels     []string `dynamodbav:"labels"`
-	Status     string   `dynamodbav:"status"`
-	CreatedAt  int64    `dynamodbav:"created_at"`
-	UpdatedAt  int64    `dynamodbav:"updated_at"`
-	TTL        int64    `dynamodbav:"ttl"`
+	RunnerID          string   `dynamodbav:"runner_id"`
+	InstanceID        string   `dynamodbav:"instance_id"`
+	JobID             int64    `dynamodbav:"job_id"`
+	RunID             int64    `dynamodbav:"run_id"`
+	Repository        string   `dynamodbav:"repository"`
+	Labels            []string `dynamodbav:"labels"`
+	Status            string   `dynamodbav:"status"`
+	CreatedAt         int64    `dynamodbav:"created_at"`
+	UpdatedAt         int64    `dynamodbav:"updated_at"`
+	TTL               int64    `dynamodbav:"ttl"`
+	GitHubRunnerID    int64    `dynamodbav:"gh_runner_id,omitempty"`
+	ReEnqueueAttempts int      `dynamodbav:"re_enqueue_attempts,omitempty"`
+	LastAttemptAt     int64    `dynamodbav:"last_attempt_at,omitempty"`
 }
 
 // NewRecord creates a runner record with sensible defaults.

--- a/lambda/internal/sqs/lifecycle_publisher.go
+++ b/lambda/internal/sqs/lifecycle_publisher.go
@@ -1,0 +1,48 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+)
+
+// LifecyclePublisher sends workflow_job lifecycle events
+// (in_progress, completed) to the lifecycle SQS queue.
+//
+// Mirrors Publisher in shape, but targets a different queue and uses no
+// delivery delay: lifecycle events should be processed promptly so the
+// runner state machine in DDB stays in sync with GitHub.
+type LifecyclePublisher struct {
+	client   Sender
+	queueURL string
+}
+
+// NewLifecyclePublisher creates a LifecyclePublisher for the given queue URL.
+func NewLifecyclePublisher(client Sender, queueURL string) *LifecyclePublisher {
+	return &LifecyclePublisher{
+		client:   client,
+		queueURL: queueURL,
+	}
+}
+
+// Publish sends a lifecycle.Message to the SQS queue with no delay.
+func (p *LifecyclePublisher) Publish(ctx context.Context, msg *lifecycle.Message) error {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal lifecycle message: %w", err)
+	}
+
+	_, err = p.client.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:    aws.String(p.queueURL),
+		MessageBody: aws.String(string(body)),
+	})
+	if err != nil {
+		return fmt.Errorf("send lifecycle SQS message: %w", err)
+	}
+	return nil
+}

--- a/lambda/internal/sqs/lifecycle_publisher_test.go
+++ b/lambda/internal/sqs/lifecycle_publisher_test.go
@@ -1,0 +1,94 @@
+package sqs
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+)
+
+func TestLifecyclePublisher_Publish(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     *lifecycle.Message
+		sendErr error
+		wantErr bool
+	}{
+		{
+			name: "in_progress publish",
+			msg: &lifecycle.Message{
+				JobID:    111,
+				Repo:     "org/repo",
+				RunnerID: 22,
+				Action:   "in_progress",
+			},
+		},
+		{
+			name: "completed publish carries conclusion",
+			msg: &lifecycle.Message{
+				JobID:      111,
+				Repo:       "org/repo",
+				RunnerID:   22,
+				Action:     "completed",
+				Conclusion: "success",
+			},
+		},
+		{
+			name: "send error",
+			msg: &lifecycle.Message{
+				JobID:  111,
+				Repo:   "org/repo",
+				Action: "in_progress",
+			},
+			sendErr: context.DeadlineExceeded,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockSQSSender{err: tt.sendErr}
+			pub := NewLifecyclePublisher(mock, "https://sqs.us-east-1.amazonaws.com/123456789/lifecycle-queue")
+
+			err := pub.Publish(context.Background(), tt.msg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if mock.lastInput == nil {
+				t.Fatal("no message sent")
+			}
+			// Lifecycle queue: no delivery delay, unlike scaleup.
+			if mock.lastInput.DelaySeconds != 0 {
+				t.Errorf("delay = %d, want 0", mock.lastInput.DelaySeconds)
+			}
+
+			var got lifecycle.Message
+			if err := json.Unmarshal([]byte(*mock.lastInput.MessageBody), &got); err != nil {
+				t.Fatalf("unmarshal sent message: %v", err)
+			}
+			if got.JobID != tt.msg.JobID {
+				t.Errorf("jobID = %d, want %d", got.JobID, tt.msg.JobID)
+			}
+			if got.Repo != tt.msg.Repo {
+				t.Errorf("repo = %q, want %q", got.Repo, tt.msg.Repo)
+			}
+			if got.RunnerID != tt.msg.RunnerID {
+				t.Errorf("runner_id = %d, want %d", got.RunnerID, tt.msg.RunnerID)
+			}
+			if got.Action != tt.msg.Action {
+				t.Errorf("action = %q, want %q", got.Action, tt.msg.Action)
+			}
+			if got.Conclusion != tt.msg.Conclusion {
+				t.Errorf("conclusion = %q, want %q", got.Conclusion, tt.msg.Conclusion)
+			}
+		})
+	}
+}

--- a/lambda/internal/sqs/types.go
+++ b/lambda/internal/sqs/types.go
@@ -8,4 +8,9 @@ type ScaleUpMessage struct {
 	RepositoryFull string   `json:"repository_full"`
 	Labels         []string `json:"labels"`
 	InstallationID int64    `json:"installation_id"`
+
+	// ReEnqueueAttempts is incremented by scaledown each time a stuck pending
+	// runner triggers a re-enqueue. Scaleup uses it as a budget check (skip
+	// launch when attempts >= MaxReEnqueueAttempts). Default zero.
+	ReEnqueueAttempts int `json:"re_enqueue_attempts,omitempty"`
 }

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -1,0 +1,59 @@
+// Package state defines the cloud-agnostic runner state-store contract.
+package state
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Status values used in Runner.Status.
+const (
+	StatusPending   = "pending"
+	StatusRunning   = "running"
+	StatusCompleted = "completed"
+	StatusFailed    = "failed"
+)
+
+// ErrNotFound is returned by RunnerStore.Get when no record exists.
+var ErrNotFound = errors.New("state: runner not found")
+
+// Runner is the persisted state for a runner managed by jit-runners.
+type Runner struct {
+	ID                string
+	InstanceID        string
+	Repository        string
+	Labels            []string
+	Status            string
+	LaunchedAt        time.Time
+	UpdatedAt         time.Time
+	TTL               time.Time
+	GitHubRunnerID    int64
+	ReEnqueueAttempts int
+	LastAttemptAt     time.Time
+}
+
+// Filter narrows a List query.
+type Filter struct {
+	StatusEq       string        // empty = no filter
+	OlderThan      time.Duration // zero = no filter (compares against LaunchedAt)
+	IncludeExpired bool
+}
+
+// RunnerUpdate carries pointer-typed fields for partial updates. nil = leave unchanged.
+type RunnerUpdate struct {
+	Status            *string
+	GitHubRunnerID    *int64
+	ReEnqueueAttempts *int
+	LastAttemptAt     *time.Time
+}
+
+// RunnerStore persists Runner records with TTL semantics. Implementations:
+// internal/aws/dynamo (DynamoDB on-demand) and internal/gcp/firestore.
+type RunnerStore interface {
+	Put(ctx context.Context, r Runner) error
+	Get(ctx context.Context, id string) (Runner, error)
+	List(ctx context.Context, f Filter) ([]Runner, error)
+	Update(ctx context.Context, id string, fields RunnerUpdate) error
+	Delete(ctx context.Context, id string) error
+}

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -43,6 +43,7 @@ type Filter struct {
 // RunnerUpdate carries pointer-typed fields for partial updates. nil = leave unchanged.
 type RunnerUpdate struct {
 	Status            *string
+	InstanceID        *string
 	GitHubRunnerID    *int64
 	ReEnqueueAttempts *int
 	LastAttemptAt     *time.Time

--- a/lambda/internal/webhook/dispatcher.go
+++ b/lambda/internal/webhook/dispatcher.go
@@ -1,0 +1,142 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+	internalsqs "github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
+)
+
+// scaleUpPublisher is the minimal surface the Handler needs from a
+// scale-up queue publisher. *internalsqs.Publisher satisfies this.
+//
+// Defined locally (rather than as a shared queue.Publisher interface)
+// so this branch does not depend on the queue-abstraction work in the
+// parallel #45 line.
+type scaleUpPublisher interface {
+	Publish(ctx context.Context, msg *internalsqs.ScaleUpMessage) error
+}
+
+// lifecyclePublisher is the minimal surface the Handler needs from the
+// lifecycle queue publisher. *internalsqs.LifecyclePublisher satisfies this.
+type lifecyclePublisher interface {
+	Publish(ctx context.Context, msg *lifecycle.Message) error
+}
+
+// Handler dispatches GitHub workflow_job webhook events to the correct
+// downstream queue based on ev.Action.
+//
+//   - queued      -> publishes a ScaleUpMessage on the scale-up queue.
+//   - in_progress -> publishes a lifecycle.Message on the lifecycle queue.
+//   - completed   -> publishes a lifecycle.Message on the lifecycle queue.
+//   - other       -> 200 OK, no publish.
+type Handler struct {
+	ScaleUpPublisher   scaleUpPublisher
+	LifecyclePublisher lifecyclePublisher
+	WebhookSecret      []byte
+}
+
+// NewHandler builds a Handler with the two publishers and the webhook
+// signing secret. webhookSecret is the raw bytes of the shared HMAC key.
+func NewHandler(scaleUp scaleUpPublisher, lifecyclePub lifecyclePublisher, webhookSecret []byte) *Handler {
+	return &Handler{
+		ScaleUpPublisher:   scaleUp,
+		LifecyclePublisher: lifecyclePub,
+		WebhookSecret:      webhookSecret,
+	}
+}
+
+// Response is the abstract outcome of handling a webhook delivery.
+// Callers (cmd/webhook/main.go for Lambda, an http.Handler shim if/when
+// added) translate this into transport-specific responses.
+type Response struct {
+	Status int
+	Body   string
+}
+
+// Handle processes one webhook delivery. It performs:
+//  1. HMAC signature verification (401 on failure).
+//  2. Dispatch by event type (only workflow_job is acted on).
+//  3. JSON parse (400 on failure).
+//  4. Action dispatch (queued/in_progress/completed/other).
+//
+// eventType is the value of the X-GitHub-Event header.
+// signature is the value of the X-Hub-Signature-256 header.
+// body is the raw request body the signature was computed over.
+func (h *Handler) Handle(ctx context.Context, eventType, signature string, body []byte) Response {
+	if err := github.VerifyWebhookSignature(body, signature, string(h.WebhookSecret)); err != nil {
+		return Response{Status: 401, Body: "Invalid signature"}
+	}
+
+	if eventType != "workflow_job" {
+		return Response{Status: 200, Body: "OK"}
+	}
+
+	result, err := Parse(body)
+	if err != nil {
+		return Response{Status: 400, Body: "Bad payload"}
+	}
+
+	switch result.Action {
+	case ActionQueued:
+		return h.handleQueued(ctx, result)
+	case ActionInProgress, ActionCompleted:
+		return h.handleLifecycle(ctx, result)
+	default:
+		return Response{Status: 200, Body: "OK"}
+	}
+}
+
+// handleQueued publishes a scale-up message when Parse marked the event
+// as needing a new runner. Otherwise it returns 200 OK without publishing
+// (e.g. non-self-hosted job, missing data flagged but recoverable).
+func (h *Handler) handleQueued(ctx context.Context, result *ParseResult) Response {
+	if !result.ShouldScale {
+		return Response{Status: 200, Body: "OK"}
+	}
+
+	msg := &internalsqs.ScaleUpMessage{
+		EventAction:    result.Action,
+		JobID:          result.Event.WorkflowJob.ID,
+		RunID:          result.Event.WorkflowJob.RunID,
+		RepositoryFull: result.Event.Repository.FullName,
+		Labels:         result.Event.WorkflowJob.Labels,
+		InstallationID: result.Event.Installation.ID,
+	}
+	if err := h.ScaleUpPublisher.Publish(ctx, msg); err != nil {
+		return Response{Status: 500, Body: "Queue error"}
+	}
+	return Response{Status: 200, Body: "OK"}
+}
+
+// handleLifecycle publishes a lifecycle.Message for in_progress / completed
+// events that target self-hosted runners. Non-self-hosted jobs are dropped
+// (200 OK) because they have no associated runner state to update.
+func (h *Handler) handleLifecycle(ctx context.Context, result *ParseResult) Response {
+	if !HasSelfHostedLabel(result.Event.WorkflowJob.Labels) {
+		return Response{Status: 200, Body: "OK"}
+	}
+
+	if h.LifecyclePublisher == nil {
+		return Response{Status: 500, Body: "Lifecycle publisher not configured"}
+	}
+
+	msg := &lifecycle.Message{
+		JobID:      result.Event.WorkflowJob.ID,
+		Repo:       result.Event.Repository.FullName,
+		RunnerID:   result.Event.WorkflowJob.RunnerID,
+		Action:     result.Action,
+		Conclusion: result.Event.WorkflowJob.Conclusion,
+	}
+	if err := h.LifecyclePublisher.Publish(ctx, msg); err != nil {
+		return Response{Status: 500, Body: "Queue error"}
+	}
+	return Response{Status: 202, Body: "Accepted"}
+}
+
+// String returns a short description of the response for log lines.
+func (r Response) String() string {
+	return fmt.Sprintf("status=%d body=%q", r.Status, r.Body)
+}

--- a/lambda/internal/webhook/dispatcher_test.go
+++ b/lambda/internal/webhook/dispatcher_test.go
@@ -1,0 +1,305 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+	internalsqs "github.com/devopsfactory-io/jit-runners/lambda/internal/sqs"
+)
+
+// fakeScaleUpPublisher captures the last ScaleUpMessage seen.
+type fakeScaleUpPublisher struct {
+	calls   int
+	last    *internalsqs.ScaleUpMessage
+	failErr error
+}
+
+func (f *fakeScaleUpPublisher) Publish(_ context.Context, msg *internalsqs.ScaleUpMessage) error {
+	f.calls++
+	f.last = msg
+	return f.failErr
+}
+
+// fakeLifecyclePublisher captures the last lifecycle.Message seen.
+type fakeLifecyclePublisher struct {
+	calls   int
+	last    *lifecycle.Message
+	rawBody []byte // serialized round-trip, for shape assertions
+	failErr error
+}
+
+func (f *fakeLifecyclePublisher) Publish(_ context.Context, msg *lifecycle.Message) error {
+	f.calls++
+	f.last = msg
+	// Round-trip through JSON so tests can assert wire shape.
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	f.rawBody = body
+	return f.failErr
+}
+
+const testSecret = "shhh"
+
+func sign(body []byte) string {
+	mac := hmac.New(sha256.New, []byte(testSecret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("..", "..", "mocks", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return body
+}
+
+func newTestHandler() (*Handler, *fakeScaleUpPublisher, *fakeLifecyclePublisher) {
+	scaleUp := &fakeScaleUpPublisher{}
+	lifeP := &fakeLifecyclePublisher{}
+	return NewHandler(scaleUp, lifeP, []byte(testSecret)), scaleUp, lifeP
+}
+
+func TestHandler_Handle_QueuedPublishesToScaleUp(t *testing.T) {
+	body := loadFixture(t, "workflow_job.queued.json")
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 200 {
+		t.Fatalf("status = %d, want 200", resp.Status)
+	}
+	if scaleUp.calls != 1 {
+		t.Errorf("scaleUp.calls = %d, want 1", scaleUp.calls)
+	}
+	if lifeP.calls != 0 {
+		t.Errorf("lifecycle.calls = %d, want 0 (no lifecycle publish on queued)", lifeP.calls)
+	}
+	if scaleUp.last == nil {
+		t.Fatal("no scale-up message captured")
+	}
+	if scaleUp.last.JobID != 123456789 {
+		t.Errorf("scaleUp.JobID = %d, want 123456789", scaleUp.last.JobID)
+	}
+	if scaleUp.last.RepositoryFull != "devopsfactory-io/jit-runners" {
+		t.Errorf("scaleUp.RepositoryFull = %q", scaleUp.last.RepositoryFull)
+	}
+	if scaleUp.last.EventAction != "queued" {
+		t.Errorf("scaleUp.EventAction = %q, want queued", scaleUp.last.EventAction)
+	}
+}
+
+func TestHandler_Handle_QueuedPublishError(t *testing.T) {
+	body := loadFixture(t, "workflow_job.queued.json")
+	h, scaleUp, _ := newTestHandler()
+	scaleUp.failErr = errors.New("boom")
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 500 {
+		t.Errorf("status = %d, want 500", resp.Status)
+	}
+}
+
+func TestHandler_Handle_InProgressPublishesToLifecycle(t *testing.T) {
+	body := loadFixture(t, "workflow_job.in_progress.json")
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 202 {
+		t.Errorf("status = %d, want 202 Accepted", resp.Status)
+	}
+	if scaleUp.calls != 0 {
+		t.Errorf("scaleUp.calls = %d, want 0", scaleUp.calls)
+	}
+	if lifeP.calls != 1 {
+		t.Fatalf("lifecycle.calls = %d, want 1", lifeP.calls)
+	}
+
+	// Assert wire shape: round-trip the published bytes and check fields.
+	var got lifecycle.Message
+	if err := json.Unmarshal(lifeP.rawBody, &got); err != nil {
+		t.Fatalf("unmarshal published lifecycle msg: %v", err)
+	}
+	if got.Action != "in_progress" {
+		t.Errorf("Action = %q, want in_progress", got.Action)
+	}
+	if got.JobID != 123456789 {
+		t.Errorf("JobID = %d, want 123456789", got.JobID)
+	}
+	if got.Repo != "devopsfactory-io/jit-runners" {
+		t.Errorf("Repo = %q", got.Repo)
+	}
+	// Conclusion is empty for in_progress.
+	if got.Conclusion != "" {
+		t.Errorf("Conclusion = %q, want \"\"", got.Conclusion)
+	}
+}
+
+func TestHandler_Handle_CompletedPublishesToLifecycle(t *testing.T) {
+	body := loadFixture(t, "workflow_job.completed.json")
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 202 {
+		t.Errorf("status = %d, want 202", resp.Status)
+	}
+	if scaleUp.calls != 0 {
+		t.Errorf("scaleUp.calls = %d, want 0", scaleUp.calls)
+	}
+	if lifeP.calls != 1 {
+		t.Fatalf("lifecycle.calls = %d, want 1", lifeP.calls)
+	}
+	if lifeP.last.Action != "completed" {
+		t.Errorf("Action = %q, want completed", lifeP.last.Action)
+	}
+}
+
+func TestHandler_Handle_LifecyclePublishError(t *testing.T) {
+	body := loadFixture(t, "workflow_job.in_progress.json")
+	h, _, lifeP := newTestHandler()
+	lifeP.failErr = errors.New("boom")
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 500 {
+		t.Errorf("status = %d, want 500 on publish failure", resp.Status)
+	}
+}
+
+func TestHandler_Handle_LifecycleNonSelfHostedDropped(t *testing.T) {
+	// In-progress event with no self-hosted label.
+	raw := []byte(`{
+		"action": "in_progress",
+		"workflow_job": {
+			"id": 42,
+			"run_id": 100,
+			"name": "build",
+			"labels": ["ubuntu-latest"],
+			"runner_name": "github-hosted",
+			"runner_id": 99,
+			"status": "in_progress"
+		},
+		"repository": {"id": 1, "full_name": "org/repo", "private": true},
+		"installation": {"id": 1}
+	}`)
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(raw), raw)
+
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200 for non-self-hosted lifecycle event", resp.Status)
+	}
+	if scaleUp.calls != 0 {
+		t.Errorf("scaleUp.calls = %d, want 0", scaleUp.calls)
+	}
+	if lifeP.calls != 0 {
+		t.Errorf("lifecycle.calls = %d, want 0 (non-self-hosted should be dropped)", lifeP.calls)
+	}
+}
+
+func TestHandler_Handle_UnknownActionNoPublish(t *testing.T) {
+	raw := []byte(`{
+		"action": "waiting",
+		"workflow_job": {
+			"id": 42,
+			"run_id": 100,
+			"name": "build",
+			"labels": ["self-hosted", "linux"],
+			"status": "waiting"
+		},
+		"repository": {"id": 1, "full_name": "org/repo", "private": true},
+		"installation": {"id": 1}
+	}`)
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(raw), raw)
+
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if scaleUp.calls != 0 || lifeP.calls != 0 {
+		t.Errorf("expected no publishes; scaleUp=%d lifecycle=%d", scaleUp.calls, lifeP.calls)
+	}
+}
+
+func TestHandler_Handle_NonWorkflowJobEventIgnored(t *testing.T) {
+	body := []byte(`{}`)
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "ping", sign(body), body)
+
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200 OK for non-workflow_job event", resp.Status)
+	}
+	if scaleUp.calls != 0 || lifeP.calls != 0 {
+		t.Errorf("expected no publishes; scaleUp=%d lifecycle=%d", scaleUp.calls, lifeP.calls)
+	}
+}
+
+func TestHandler_Handle_BadSignature(t *testing.T) {
+	body := loadFixture(t, "workflow_job.queued.json")
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", "sha256=deadbeef", body)
+
+	if resp.Status != 401 {
+		t.Errorf("status = %d, want 401", resp.Status)
+	}
+	if scaleUp.calls != 0 || lifeP.calls != 0 {
+		t.Error("no publish should occur on invalid signature")
+	}
+}
+
+func TestHandler_Handle_BadJSON(t *testing.T) {
+	body := []byte(`{not json}`)
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+
+	if resp.Status != 400 {
+		t.Errorf("status = %d, want 400", resp.Status)
+	}
+	if scaleUp.calls != 0 || lifeP.calls != 0 {
+		t.Error("no publish should occur on bad JSON")
+	}
+}
+
+func TestHandler_Handle_QueuedNonSelfHostedNoPublish(t *testing.T) {
+	// queued event but with no self-hosted label -> Parse marks ShouldScale=false.
+	raw := []byte(`{
+		"action": "queued",
+		"workflow_job": {
+			"id": 1,
+			"run_id": 2,
+			"name": "build",
+			"labels": ["ubuntu-latest"],
+			"status": "queued"
+		},
+		"repository": {"id": 1, "full_name": "org/repo", "private": true},
+		"installation": {"id": 1}
+	}`)
+	h, scaleUp, lifeP := newTestHandler()
+
+	resp := h.Handle(context.Background(), "workflow_job", sign(raw), raw)
+
+	if resp.Status != 200 {
+		t.Errorf("status = %d, want 200", resp.Status)
+	}
+	if scaleUp.calls != 0 || lifeP.calls != 0 {
+		t.Errorf("expected no publishes; scaleUp=%d lifecycle=%d", scaleUp.calls, lifeP.calls)
+	}
+}

--- a/lambda/internal/webhook/handler.go
+++ b/lambda/internal/webhook/handler.go
@@ -42,7 +42,7 @@ func Parse(body []byte) (*ParseResult, error) {
 	}
 
 	// The job must request self-hosted runners.
-	if !hasSelfHostedLabel(event.WorkflowJob.Labels) {
+	if !HasSelfHostedLabel(event.WorkflowJob.Labels) {
 		return result, nil
 	}
 
@@ -53,16 +53,6 @@ func Parse(body []byte) (*ParseResult, error) {
 
 	result.ShouldScale = true
 	return result, nil
-}
-
-// hasSelfHostedLabel checks if the labels include "self-hosted".
-func hasSelfHostedLabel(labels []string) bool {
-	for _, l := range labels {
-		if strings.EqualFold(l, "self-hosted") {
-			return true
-		}
-	}
-	return false
 }
 
 // CustomLabels returns the job's labels excluding standard GitHub labels

--- a/lambda/internal/webhook/types.go
+++ b/lambda/internal/webhook/types.go
@@ -1,5 +1,7 @@
 package webhook
 
+import "strings"
+
 // WorkflowJobEvent represents the GitHub workflow_job webhook event payload.
 type WorkflowJobEvent struct {
 	Action       string        `json:"action"`
@@ -16,7 +18,21 @@ type WorkflowJob struct {
 	Name       string   `json:"name"`
 	Labels     []string `json:"labels"`
 	RunnerName string   `json:"runner_name"`
+	RunnerID   int64    `json:"runner_id"`
 	Status     string   `json:"status"`
+	Conclusion string   `json:"conclusion"`
+}
+
+// HasSelfHostedLabel returns true when the labels include "self-hosted"
+// (case-insensitive). Exposed for use by the lifecycle dispatch path so
+// we drop events that target GitHub-hosted runners.
+func HasSelfHostedLabel(labels []string) bool {
+	for _, l := range labels {
+		if strings.EqualFold(l, "self-hosted") {
+			return true
+		}
+	}
+	return false
 }
 
 // Repository identifies the repository that triggered the workflow.


### PR DESCRIPTION
## Summary

Closes #47.

Adds full `workflow_job` lifecycle tracking and recovery from GitHub-side scheduler hiccups. Surfaced by [PR #46](https://github.com/devopsfactory-io/jit-runners/pull/46) where 2 `[self-hosted, large]` jobs were stuck `queued` for 30+ min despite spot c5.xlarge instances spawning, registering, completing matching jobs, and self-terminating cleanly.

## What changes

- **Webhook** dispatches by `workflow_job.action`. `queued` (existing) → scaleup queue. `in_progress` + `completed` (NEW) → new lifecycle queue.
- **New `lifecycle` Lambda + SQS queue + DLQ.** Consumes lifecycle events, updates DDB through `pending → running → completed`, calls `github.Client.DeregisterRunner` on `completed` (404 = ok).
- **Scaleup** persists `GitHubRunnerID` to DDB after `GenerateJITConfig`; deregisters on launch failure; idempotency guard skips re-launch only when status is `running` (not `pending` or `failed`). Also fixes a pre-existing `JITRunnerConfig` JSON-shape bug — was decoding flat `runner_id` (always 0); now correctly nested under `runner.id`.
- **Scaledown** gains the re-enqueue path (`ReEnqueueAttempts++` until `MaxReEnqueueAttempts`, default 3) and a separate stale-running reaper that terminates + deregisters but **never** re-enqueues (avoids double-launch when GitHub may already consider the job done).
- 3 new `state.Runner` fields: `GitHubRunnerID`, `ReEnqueueAttempts`, `LastAttemptAt`. Existing live DDB records unaffected (zero-value tolerant via `omitempty`).
- Cloud-agnostic interfaces: `state.RunnerStore.Update(ctx, id, RunnerUpdate)` and `github.Client.DeregisterRunner` added; AWS impls updated. `runner.StateAdapter` bridges the existing `*Store` to `state.RunnerStore` shape for the lifecycle handler.
- **IaC:** CFN + Terraform define lifecycle queue, DLQ, function, role, event-source mapping, 3 new parameters (`LifecycleLambdaS3Key`, `MaxReEnqueueAttempts` default 3, `GitHubInstallationId`), 3 new outputs. Webhook + scaledown roles + envs updated.
- **`.goreleaser.yml`** builds + archives the new lifecycle binary alongside the existing three.
- **`docs/release.md`** updated for 4-function rollout (rename, upload, update-stack, verify, rollback).
- **`docs/troubleshooting.md`** new "Re-enqueue and DLQ inspection" section.

## Test plan

- [ ] CI green on `[self-hosted, large]` (`lint` + `fmt, vet, test and coverage`) and `[self-hosted, medium]` (labeler).
- [ ] CodeQL Go analysis, Scorecard PR Check, Vulnerability Scan, Secret Scan all pass.
- [ ] DCO sign-off check.
- [ ] (Manual, post-merge) `tofu plan` against `infra/terraform/` shows ONLY additive resource creation + parameter additions — no replacement of existing functions, queues, table, or roles.
- [ ] (Manual, post-merge) Deploy v1.0.0-rc.1, verify all 4 Lambda CodeSha256 values, smoke test PR #46 rebase.

## Quality gates verified locally

- 108 tests passing across 12 Go packages.
- All 4 Lambda binaries build (webhook, scaleup, scaledown, lifecycle).
- `go vet`, `gofmt -l`, `golangci-lint`, `aws cloudformation validate-template`, `tofu validate` — all clean.
- DCO sign-off on all 20 commits.

## GitHub App configuration

**No changes required.** Webhook logs verify `queued`, `in_progress`, and `completed` events are already delivered. The new `DELETE /repos/.../actions/runners/{id}` endpoint uses the same `administration:write` scope as the existing `generate-jitconfig` call.

## Caveat — chicken-and-egg CI flake

The bug this PR fixes also affects this PR's own CI: stranded `queued` jobs are the symptom. If the test workflow flakes, cancel + push an empty commit to retry; the fix becomes effective once the new lambdas are deployed (Phase J post-merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle runner management function to handle GitHub workflow state transitions
  * Implemented re-enqueue mechanism for stuck pending jobs with configurable retry limits
  * Added lifecycle message queue and dead-letter queue for runner state events

* **Documentation**
  * Updated release procedure to include lifecycle function deployment
  * Added troubleshooting guide for diagnosing and resolving stuck queued jobs

* **Infrastructure**
  * New SQS queues for lifecycle event processing
  * Updated CloudFormation and Terraform configurations with lifecycle Lambda and messaging infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->