### PR TITLE
fix(runners): track JIT runners by runner_id, not job_id

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -525,5 +525,38 @@ aws sqs send-message \
   --region us-east-2
 ```
 
-The scaleup function's idempotency guard (`Status == StatusRunning` → skip)
-ensures this is safe even if the original runner did register.
+Under the runner_id identity model (issue #52), each scaleup invocation registers a fresh JIT runner with a unique `runner_id` and launches a new EC2 instance — there is no `(repo, job_id)`-keyed idempotency check that could short-circuit a manual re-enqueue. If the prior runner is still alive when you re-enqueue, scaledown's `Scan`-based stale-runner sweep reaps the abandoned instance after `StaleThresholdMinutes`. This is generally what you want for a manual reset.
+
+## How runners bind to jobs
+
+This subsection documents what GitHub actually guarantees about JIT runner-to-job binding, so future maintainers do not re-make the assumption that produced issue #52.
+
+### What GitHub guarantees
+
+The endpoint `POST /repos/{owner}/{repo}/actions/runners/generate-jitconfig` accepts only:
+
+- `name` — a cosmetic identifier (any string, no semantic binding).
+- `runner_group_id` — group membership.
+- `labels` — array of labels the runner advertises.
+- `work_folder` — optional working directory hint for the runner agent.
+
+There is **no** `job_id` parameter and **no** `workflow_run_id` parameter. The endpoint guarantees: *"when a runner registers using this API it will only be allowed to run a single job before being automatically removed from the repository, organization, or enterprise."*
+
+That single job is **whichever queued job whose labels match first** — not job-locked, not workflow_run-locked.
+
+### What this means for jit-runners
+
+- Each `workflow_job=queued` event triggers one `generate-jitconfig` call and one EC2 spot launch. GitHub returns a unique int64 `runner_id` per call.
+- DynamoDB records are keyed on the stringified `runner_id` (the only stable identifier post-registration). `job_id` and `workflow_run_id` are stored as observability metadata only.
+- When a runner comes online, GitHub assigns it one of the queued matching jobs **non-deterministically**. The runner whose name happens to encode `job_id=A` may execute `job_id=B`. Total job count drains, but pairing is set-level, not name-level.
+- Lifecycle webhooks (`workflow_job=in_progress`, `workflow_job=completed`) carry the `runner_id` of the runner that actually executed the job. Because we key DDB on `runner_id`, every webhook resolves its own record exactly once.
+
+### Why the runner name is `jit-<uuidv4>`
+
+The previous form `jit-<job_id>` implied a binding GitHub does not enforce. Future readers must not assume the trailing component of a JIT runner name is meaningful. A UUID is opaque by construction.
+
+### References
+
+- [REST API: self-hosted runners](https://docs.github.com/en/rest/actions/self-hosted-runners) — `generate-jitconfig` request body.
+- [GitHub Changelog: Just-in-time self-hosted runners (2023-06-02)](https://github.blog/changelog/2023-06-02-github-actions-just-in-time-self-hosted-runners/).
+- Issue [devopsfactory-io/jit-runners#52](https://github.com/devopsfactory-io/jit-runners/issues/52) and the design spec at `repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-runner-id-realignment-design.md`.

--- a/lambda/cmd/lifecycle/main_integration_test.go
+++ b/lambda/cmd/lifecycle/main_integration_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
+)
+
+// fakeGitHub records DeregisterRunner calls; used to assert the lifecycle
+// handler hits the deregister path on completed.
+type fakeGitHub struct {
+	calls []deregCall
+	err   error
+}
+
+type deregCall struct {
+	repo     string
+	runnerID int64
+}
+
+func (f *fakeGitHub) DeregisterRunner(_ context.Context, repo string, runnerID int64) error {
+	f.calls = append(f.calls, deregCall{repo: repo, runnerID: runnerID})
+	return f.err
+}
+
+func newHandler(store state.RunnerStore, gh *fakeGitHub) *lifecycle.Handler {
+	return lifecycle.New(store, gh, log.New(os.Stderr, "test ", 0))
+}
+
+func TestLifecycle_InProgressThenCompleted_FollowsRunnerID(t *testing.T) {
+	store := memstore.New()
+	ctx := context.Background()
+
+	// Seed at key "999" — the stringified GitHub runner_id.
+	seed := state.Runner{
+		ID:             "999",
+		Status:         state.StatusPending,
+		GitHubRunnerID: 999,
+		Repository:     "owner/repo",
+		JobID:          4567,
+		WorkflowRunID:  8910,
+	}
+	if err := store.Put(ctx, seed); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	gh := &fakeGitHub{}
+	h := newHandler(store, gh)
+
+	// in_progress -> running, no deregister yet.
+	body := []byte(`{"job_id":4567,"repo":"owner/repo","runner_id":999,"action":"in_progress"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS in_progress: %v", err)
+	}
+	got, _ := store.Get(ctx, "999")
+	if got.Status != state.StatusRunning {
+		t.Errorf("after in_progress: Status = %q, want %q", got.Status, state.StatusRunning)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("in_progress should not deregister: calls=%+v", gh.calls)
+	}
+
+	// completed -> completed + deregister(999, owner/repo).
+	body = []byte(`{"job_id":4567,"repo":"owner/repo","runner_id":999,"action":"completed"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS completed: %v", err)
+	}
+	got, _ = store.Get(ctx, "999")
+	if got.Status != state.StatusCompleted {
+		t.Errorf("after completed: Status = %q, want %q", got.Status, state.StatusCompleted)
+	}
+	if len(gh.calls) != 1 || gh.calls[0].runnerID != 999 || gh.calls[0].repo != "owner/repo" {
+		t.Errorf("deregister calls = %+v, want one with runnerID=999 repo=owner/repo", gh.calls)
+	}
+}
+
+func TestLifecycle_DropsWhenRunnerIDZero(t *testing.T) {
+	store := memstore.New()
+	gh := &fakeGitHub{}
+	h := newHandler(store, gh)
+
+	body := []byte(`{"job_id":4567,"repo":"owner/repo","runner_id":0,"action":"completed"}`)
+	if err := h.HandleSQS(context.Background(), body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("zero runner_id must drop without deregister; calls=%+v", gh.calls)
+	}
+}
+
+func TestLifecycle_DropsWhenRecordAbsent(t *testing.T) {
+	store := memstore.New()
+	gh := &fakeGitHub{}
+	h := newHandler(store, gh)
+
+	body := []byte(`{"job_id":4567,"repo":"owner/repo","runner_id":12345,"action":"completed"}`)
+	if err := h.HandleSQS(context.Background(), body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("absent record must drop without deregister; calls=%+v", gh.calls)
+	}
+}

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -24,6 +23,7 @@ import (
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/webhook"
+	"github.com/google/uuid"
 )
 
 const defaultRunnerVersion = "2.332.0"
@@ -72,48 +72,33 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 		return nil // don't retry malformed messages
 	}
 
-	// Idempotency check. Skip only when an in-flight runner is already
-	// registered and running. A pending record may be a partial write from a
-	// prior attempt that died before Launch — we still want to retry. A
-	// failed record (e.g. written by scaledown after a stale-pending reap)
-	// signals the runner was deregistered and the message has been
-	// re-enqueued, so a fresh registration + launch is appropriate.
-	id := runner.ID(msg.RepositoryFull, msg.JobID)
-	existing, err := store.Get(ctx, id)
-	if err != nil && !errors.Is(err, state.ErrNotFound) {
-		return fmt.Errorf("check existing runner: %w", err)
-	}
-	recordExists := !errors.Is(err, state.ErrNotFound) && existing.ID != ""
-	if recordExists && existing.Status == state.StatusRunning {
-		log.Printf("runner already running for %s job=%d, skipping", msg.RepositoryFull, msg.JobID)
-		return nil
-	}
-
 	// Get installation token.
 	token, err := github.InstallationToken(ctx, cfg.AppID, cfg.PrivateKey, msg.InstallationID)
 	if err != nil {
 		return fmt.Errorf("get installation token: %w", err)
 	}
 
-	// Generate JIT runner config. Note the runner is registered with GitHub
-	// at this point; if anything below fails we must deregister it.
+	// Generate JIT runner config. The runner is registered with GitHub at
+	// this point; if anything below fails we must deregister it. The runner
+	// name is purely cosmetic per GitHub's JIT contract — we use a UUID so
+	// no future reader assumes a binding to job_id or workflow_run_id.
 	ghClient := github.NewClient(token)
-	runnerName := fmt.Sprintf("jit-%d", msg.JobID)
+	runnerName := "jit-" + uuid.NewString()
 	customLabels := webhook.CustomLabels(msg.Labels)
 	jitCfg, err := ghClient.GenerateJITConfig(ctx, msg.RepositoryFull, runnerName, msg.Labels)
 	if err != nil {
 		return fmt.Errorf("generate JIT config: %w", err)
 	}
 
-	// Persist a pending record BEFORE launching the EC2 instance so that
-	// scaledown's stale-pending sweep can reap orphans if scaleup itself
-	// dies between RunInstances and the post-launch update. The record
-	// carries the GitHub runner ID (for deregistration) and the re-enqueue
-	// counter.
-	pending := runner.New(msg.RepositoryFull, msg.JobID, "", msg.Labels)
-	pending.GitHubRunnerID = jitCfg.Runner.ID
+	// Persist a pending record keyed on the GitHub runner_id BEFORE
+	// launching the EC2 instance so scaledown's stale-pending sweep can
+	// reap orphans if scaleup itself dies between RunInstances and the
+	// post-launch update. The record carries jitCfg.Runner.ID as both the
+	// primary key and the GitHubRunnerID attribute. JobID and
+	// WorkflowRunID are observability metadata, never lookup keys.
+	pending := runner.New(msg.RepositoryFull, jitCfg.Runner.ID, "", msg.JobID, msg.RunID, msg.Labels)
 	pending.ReEnqueueAttempts = msg.ReEnqueueAttempts
-	if err := writePendingRecord(ctx, ghClient, store, msg, pending, recordExists); err != nil {
+	if err := writePendingRecord(ctx, ghClient, store, msg, pending); err != nil {
 		return err
 	}
 
@@ -167,45 +152,26 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 		// The instance is launched and the runner is registered — log and
 		// continue so the message is ack'd. Scaledown will reconcile if
 		// anything goes wrong from here.
-		log.Printf("failed to update runner record with instance %s for %s job=%d: %v",
-			inst.ID, msg.RepositoryFull, msg.JobID, err)
+		log.Printf("failed to update runner record with instance %s for runner=%d job=%d: %v",
+			inst.ID, jitCfg.Runner.ID, msg.JobID, err)
 	}
 
-	log.Printf("launched instance %s for %s job=%d", inst.ID, msg.RepositoryFull, msg.JobID)
+	log.Printf("launched instance %s for runner=%d job=%d (%s)",
+		inst.ID, jitCfg.Runner.ID, msg.JobID, msg.RepositoryFull)
 	return nil
 }
 
-// writePendingRecord persists pending as the pre-launch state. If a
-// non-running record already exists (recordExists=true), the writer Updates
-// the existing row instead of Putting. Any failure deregisters the GitHub
-// runner so we don't leak registration state.
-func writePendingRecord(ctx context.Context, gh *github.Client, store state.RunnerStore, msg *awssqs.ScaleUpMessage, pending state.Runner, recordExists bool) error {
-	if !recordExists {
-		if err := store.Put(ctx, pending); err != nil {
-			if derr := gh.DeregisterRunner(ctx, msg.RepositoryFull, pending.GitHubRunnerID); derr != nil {
-				log.Printf("deregister after pending-put failure for %s job=%d: %v", msg.RepositoryFull, msg.JobID, derr)
-			}
-			return fmt.Errorf("put pending runner record: %w", err)
-		}
-		return nil
-	}
-	// Refresh the existing non-running record (typically pending or failed
-	// from a prior attempt) so the GitHub runner ID and re-enqueue counter
-	// reflect the current attempt before launch.
-	now := time.Now()
-	statusPending := state.StatusPending
-	ghID := pending.GitHubRunnerID
-	attempts := pending.ReEnqueueAttempts
-	if err := store.Update(ctx, pending.ID, state.RunnerUpdate{
-		Status:            &statusPending,
-		GitHubRunnerID:    &ghID,
-		ReEnqueueAttempts: &attempts,
-		LastAttemptAt:     &now,
-	}); err != nil {
+// writePendingRecord persists pending as the pre-launch state. Always a
+// fresh Put — the partition key is the just-returned GitHub runner_id and
+// no prior record can exist at that key. On Put failure we deregister the
+// GitHub runner so we don't leak registration state.
+func writePendingRecord(ctx context.Context, gh *github.Client, store state.RunnerStore, msg *awssqs.ScaleUpMessage, pending state.Runner) error {
+	if err := store.Put(ctx, pending); err != nil {
 		if derr := gh.DeregisterRunner(ctx, msg.RepositoryFull, pending.GitHubRunnerID); derr != nil {
-			log.Printf("deregister after pending-update failure for %s job=%d: %v", msg.RepositoryFull, msg.JobID, derr)
+			log.Printf("deregister after pending-put failure for runner=%d job=%d: %v",
+				pending.GitHubRunnerID, msg.JobID, derr)
 		}
-		return fmt.Errorf("refresh pending runner record: %w", err)
+		return fmt.Errorf("put pending runner record: %w", err)
 	}
 	return nil
 }
@@ -216,7 +182,7 @@ func writePendingRecord(ctx context.Context, gh *github.Client, store state.Runn
 // error.
 func markLaunchFailed(ctx context.Context, gh *github.Client, store state.RunnerStore, msg *awssqs.ScaleUpMessage, recordID string, ghRunnerID int64) {
 	if err := gh.DeregisterRunner(ctx, msg.RepositoryFull, ghRunnerID); err != nil {
-		log.Printf("deregister runner %d after launch failure for %s job=%d: %v",
+		log.Printf("deregister runner=%d after launch failure for %s job=%d: %v",
 			ghRunnerID, msg.RepositoryFull, msg.JobID, err)
 	}
 	now := time.Now()
@@ -225,7 +191,8 @@ func markLaunchFailed(ctx context.Context, gh *github.Client, store state.Runner
 		Status:        &failed,
 		LastAttemptAt: &now,
 	}); err != nil {
-		log.Printf("mark runner failed for %s job=%d: %v", msg.RepositoryFull, msg.JobID, err)
+		log.Printf("mark runner failed for runner=%d job=%d: %v",
+			ghRunnerID, msg.JobID, err)
 	}
 }
 

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	awsec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/google/uuid"
 
 	awsdynamo "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/dynamo"
 	awsec2 "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ec2"
@@ -23,7 +24,6 @@ import (
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/webhook"
-	"github.com/google/uuid"
 )
 
 const defaultRunnerVersion = "2.332.0"

--- a/lambda/cmd/scaleup/main_integration_test.go
+++ b/lambda/cmd/scaleup/main_integration_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/google/uuid"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
+	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
+)
+
+// fakeLauncher is a minimal compute.Launcher for tests.
+type fakeLauncher struct {
+	launchErr error
+	launches  []compute.LaunchSpec
+}
+
+func (f *fakeLauncher) Launch(_ context.Context, spec compute.LaunchSpec) (compute.Instance, error) {
+	f.launches = append(f.launches, spec)
+	if f.launchErr != nil {
+		return compute.Instance{}, f.launchErr
+	}
+	return compute.Instance{ID: "i-test123"}, nil
+}
+
+func (f *fakeLauncher) Terminate(_ context.Context, _ []string) error { return nil }
+
+func (f *fakeLauncher) ListStale(_ context.Context, _ time.Duration) ([]compute.Instance, error) {
+	return nil, nil
+}
+
+// TestProcessRecord_ParseFailureIsNoOp verifies that malformed SQS bodies
+// short-circuit before any side-effects: no instance launches, no GitHub
+// API calls, no DDB writes. processRecord returns nil so SQS does not retry.
+func TestProcessRecord_ParseFailureIsNoOp(t *testing.T) {
+	cfg := &appconfig.Config{}
+	launcher := &fakeLauncher{}
+	store := memstore.New()
+
+	rec := events.SQSMessage{Body: "{not json"}
+	if err := processRecord(context.Background(), cfg, launcher, store, rec); err != nil {
+		t.Fatalf("processRecord on bad JSON should return nil to avoid retry; got %v", err)
+	}
+	if len(launcher.launches) != 0 {
+		t.Errorf("expected no launches, got %d", len(launcher.launches))
+	}
+}
+
+// TestRunnerNameMatchesUUIDPattern pins the jit-<uuidv4> contract for the
+// runner name. processRecord constructs the name as "jit-" + uuid.NewString();
+// this test re-creates a name through the same pathway and asserts the
+// canonical 36-char UUID format.
+func TestRunnerNameMatchesUUIDPattern(t *testing.T) {
+	pat := regexp.MustCompile(`^jit-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	name := "jit-" + uuid.NewString()
+	if !pat.MatchString(name) {
+		t.Errorf("runner name %q does not match jit-<uuidv4>", name)
+	}
+}
+
+// TestPendingRecordKeyedByGitHubRunnerID exercises runner.New + memstore to
+// pin the new identity contract: a Runner built for GitHub runner_id 999
+// persists at key "999", and the legacy "<repo>#<job_id>" key is
+// unreachable post-cutover.
+func TestPendingRecordKeyedByGitHubRunnerID(t *testing.T) {
+	store := memstore.New()
+	ctx := context.Background()
+
+	pending := runner.New("owner/repo", 999, "", 4567, 8910, []string{"self-hosted", "large"})
+	if pending.ID != "999" {
+		t.Fatalf("runner.New ID invariant violated: got %q, want %q", pending.ID, "999")
+	}
+
+	if err := store.Put(ctx, pending); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := store.Get(ctx, "999")
+	if err != nil {
+		t.Fatalf(`Get "999": %v`, err)
+	}
+	if got.GitHubRunnerID != 999 {
+		t.Errorf("GitHubRunnerID = %d, want 999", got.GitHubRunnerID)
+	}
+	if got.JobID != 4567 {
+		t.Errorf("JobID = %d, want 4567", got.JobID)
+	}
+	if got.WorkflowRunID != 8910 {
+		t.Errorf("WorkflowRunID = %d, want 8910", got.WorkflowRunID)
+	}
+
+	if _, err := store.Get(ctx, "owner/repo#4567"); !errors.Is(err, state.ErrNotFound) {
+		t.Errorf("legacy key 'owner/repo#4567' must be unreachable; got err=%v", err)
+	}
+}

--- a/lambda/go.mod
+++ b/lambda/go.mod
@@ -29,4 +29,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 )

--- a/lambda/go.mod
+++ b/lambda/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.5
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 )
 
 require (
@@ -29,5 +30,4 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 )

--- a/lambda/go.sum
+++ b/lambda/go.sum
@@ -46,6 +46,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=

--- a/lambda/internal/aws/dynamo/store.go
+++ b/lambda/internal/aws/dynamo/store.go
@@ -65,22 +65,6 @@ type dbRecord struct {
 	LastAttemptAt     int64    `dynamodbav:"last_attempt_at,omitempty"`
 }
 
-// JobID returns the trailing numeric component of a runner ID encoded as
-// "<repository>#<jobID>". Returns 0 when the ID is malformed; this is best
-// effort because JobID is denormalized into the record purely for queryable
-// joins, not as a source of truth.
-func parseJobID(id string) int64 {
-	idx := strings.LastIndex(id, "#")
-	if idx < 0 || idx == len(id)-1 {
-		return 0
-	}
-	n, err := strconv.ParseInt(id[idx+1:], 10, 64)
-	if err != nil {
-		return 0
-	}
-	return n
-}
-
 func toDB(r state.Runner) dbRecord {
 	createdAt := r.LaunchedAt
 	if createdAt.IsZero() {
@@ -101,7 +85,8 @@ func toDB(r state.Runner) dbRecord {
 	return dbRecord{
 		RunnerID:          r.ID,
 		InstanceID:        r.InstanceID,
-		JobID:             parseJobID(r.ID),
+		JobID:             r.JobID,
+		RunID:             r.WorkflowRunID,
 		Repository:        r.Repository,
 		Labels:            r.Labels,
 		Status:            r.Status,
@@ -129,6 +114,8 @@ func fromDB(d dbRecord) state.Runner {
 		UpdatedAt:         time.Unix(d.UpdatedAt, 0).UTC(),
 		TTL:               time.Unix(d.TTL, 0).UTC(),
 		GitHubRunnerID:    d.GitHubRunnerID,
+		JobID:             d.JobID,
+		WorkflowRunID:     d.RunID,
 		ReEnqueueAttempts: d.ReEnqueueAttempts,
 		LastAttemptAt:     lastAttempt,
 	}

--- a/lambda/internal/aws/dynamo/store_test.go
+++ b/lambda/internal/aws/dynamo/store_test.go
@@ -23,15 +23,41 @@ type mockDDB struct {
 	getOut      *dynamodb.GetItemOutput
 	scanOut     *dynamodb.ScanOutput
 	err         error
+	items       map[string]map[string]types.AttributeValue
 }
 
 func (m *mockDDB) PutItem(_ context.Context, in *dynamodb.PutItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error) {
 	m.putInput = in
+	if m.items != nil {
+		key := ""
+		if v, ok := in.Item["runner_id"]; ok {
+			if sv, ok := v.(*types.AttributeValueMemberS); ok {
+				key = sv.Value
+			}
+		}
+		if key != "" {
+			m.items[key] = in.Item
+		}
+	}
 	return &dynamodb.PutItemOutput{}, m.err
 }
 
 func (m *mockDDB) GetItem(_ context.Context, in *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
 	m.getInput = in
+	if m.items != nil {
+		key := ""
+		if v, ok := in.Key["runner_id"]; ok {
+			if sv, ok := v.(*types.AttributeValueMemberS); ok {
+				key = sv.Value
+			}
+		}
+		if key != "" {
+			if item, found := m.items[key]; found {
+				return &dynamodb.GetItemOutput{Item: item}, m.err
+			}
+		}
+		return &dynamodb.GetItemOutput{}, m.err
+	}
 	if m.getOut != nil {
 		return m.getOut, m.err
 	}
@@ -217,6 +243,40 @@ func TestStore_Delete(t *testing.T) {
 	}
 	if mock.deleteInput == nil {
 		t.Fatal("DeleteItem was not called")
+	}
+}
+
+func TestStore_Put_RoundTripsJobIDAndWorkflowRunID(t *testing.T) {
+	ddb := &mockDDB{items: map[string]map[string]types.AttributeValue{}}
+	store := NewStore(ddb, "test-table")
+	ctx := context.Background()
+
+	r := state.Runner{
+		ID:             "12345",
+		InstanceID:     "i-abc",
+		Repository:     "owner/repo",
+		Labels:         []string{"self-hosted", "large"},
+		Status:         state.StatusPending,
+		LaunchedAt:     time.Unix(1700000000, 0).UTC(),
+		UpdatedAt:      time.Unix(1700000000, 0).UTC(),
+		TTL:            time.Unix(1700086400, 0).UTC(),
+		GitHubRunnerID: 12345,
+		JobID:          678,
+		WorkflowRunID:  9012,
+	}
+
+	if err := store.Put(ctx, r); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := store.Get(ctx, "12345")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.JobID != 678 {
+		t.Errorf("JobID = %d, want 678", got.JobID)
+	}
+	if got.WorkflowRunID != 9012 {
+		t.Errorf("WorkflowRunID = %d, want 9012", got.WorkflowRunID)
 	}
 }
 

--- a/lambda/internal/lifecycle/handler.go
+++ b/lambda/internal/lifecycle/handler.go
@@ -5,18 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
-
-// runnerID computes the DDB primary key from repo + jobID. Mirrors the
-// scaleup helper. A future refactor (Phase B3 in the plan) consolidates
-// this in the runner package; for now it is local to lifecycle to keep
-// this branch self-contained.
-func runnerID(repo string, jobID int64) string {
-	return fmt.Sprintf("%s#%d", repo, jobID)
-}
 
 // nextStatus is the forward-only state-machine transition table.
 // (current, action) -> (next, ok). ok=false means: drop the message
@@ -44,17 +37,33 @@ func nextStatus(current, action string) (next string, ok bool) {
 }
 
 // HandleSQS processes one SQS record body. Idempotent.
+//
+// Lookups key on msg.RunnerID — the int64 GitHub returned from
+// generate-jitconfig and that GitHub populates in workflow_job webhook
+// deliveries. Per issue #52, this is the only stable runner identifier;
+// the prior (repo, job_id) lookup was racy under concurrent jobs.
 func (h *Handler) HandleSQS(ctx context.Context, body []byte) error {
 	var msg Message
 	if err := json.Unmarshal(body, &msg); err != nil {
 		return fmt.Errorf("lifecycle: parse: %w", err)
 	}
 
-	key := runnerID(msg.Repo, msg.JobID)
+	if msg.RunnerID == 0 {
+		// Defensive: GitHub did not populate runner_id in the webhook
+		// payload. There is no record to update; drop the message
+		// without a lookup so we do not pollute logs with bogus
+		// "no record at key 0" entries.
+		h.Logger.Printf("lifecycle: drop %s job=%d action=%s: missing runner_id",
+			msg.Repo, msg.JobID, msg.Action)
+		return nil
+	}
+
+	key := strconv.FormatInt(msg.RunnerID, 10)
 	rec, err := h.Store.Get(ctx, key)
 	switch {
 	case errors.Is(err, state.ErrNotFound):
-		h.Logger.Printf("lifecycle: drop %s job=%d action=%s: no record", msg.Repo, msg.JobID, msg.Action)
+		h.Logger.Printf("lifecycle: drop %s job=%d runner=%d action=%s: no record",
+			msg.Repo, msg.JobID, msg.RunnerID, msg.Action)
 		return nil
 	case err != nil:
 		return fmt.Errorf("lifecycle: get %s: %w", key, err)
@@ -62,8 +71,8 @@ func (h *Handler) HandleSQS(ctx context.Context, body []byte) error {
 
 	next, ok := nextStatus(rec.Status, msg.Action)
 	if !ok {
-		h.Logger.Printf("lifecycle: drop %s job=%d action=%s: backward transition from %s",
-			msg.Repo, msg.JobID, msg.Action, rec.Status)
+		h.Logger.Printf("lifecycle: drop %s job=%d runner=%d action=%s: backward transition from %s",
+			msg.Repo, msg.JobID, msg.RunnerID, msg.Action, rec.Status)
 		return nil
 	}
 	if next == rec.Status {

--- a/lambda/internal/lifecycle/handler_test.go
+++ b/lambda/internal/lifecycle/handler_test.go
@@ -78,15 +78,15 @@ func TestHandleSQS_TransitionTable(t *testing.T) {
 		{"completed+in_progress -> drop (backward)", state.StatusCompleted, "in_progress", 99, state.StatusCompleted, false, false},
 		{"running+in_progress -> no-op", state.StatusRunning, "in_progress", 99, state.StatusRunning, false, false},
 		{"completed+unknown_action -> drop", state.StatusCompleted, "waiting", 99, state.StatusCompleted, false, false},
-		{"completed with zero runnerID -> update only", state.StatusRunning, "completed", 0, state.StatusCompleted, true, false},
 	}
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			store := &fakeStore{get: state.Runner{
-				ID:             "owner/repo#1",
+				ID:             "99",
 				Status:         tc.current,
 				GitHubRunnerID: tc.ghRunnerID,
+				Repository:     "owner/repo",
 			}}
 			gh := &fakeGitHub{}
 			h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
@@ -101,6 +101,9 @@ func TestHandleSQS_TransitionTable(t *testing.T) {
 				t.Errorf("update: got %v want %v (updates=%+v)", gotUpdate, tc.wantUpdate, store.updates)
 			}
 			if tc.wantUpdate {
+				if store.updates[0].id != "99" {
+					t.Errorf("update key: got %q want %q", store.updates[0].id, "99")
+				}
 				if store.updates[0].fields.Status == nil {
 					t.Fatal("Status: expected non-nil pointer")
 				}
@@ -116,14 +119,6 @@ func TestHandleSQS_TransitionTable(t *testing.T) {
 			if gotDereg != tc.wantDeregister {
 				t.Errorf("deregister: got %v want %v (calls=%+v)", gotDereg, tc.wantDeregister, gh.calls)
 			}
-			if tc.wantDeregister {
-				if gh.calls[0].runnerID != tc.ghRunnerID {
-					t.Errorf("deregister runnerID: got %d want %d", gh.calls[0].runnerID, tc.ghRunnerID)
-				}
-				if gh.calls[0].repo != "owner/repo" {
-					t.Errorf("deregister repo: got %q want %q", gh.calls[0].repo, "owner/repo")
-				}
-			}
 		})
 	}
 }
@@ -133,7 +128,28 @@ func TestHandleSQS_UnknownRecordDrops(t *testing.T) {
 	gh := &fakeGitHub{}
 	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
 
-	body := []byte(`{"job_id":1,"repo":"owner/repo","action":"completed"}`)
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
+	if err := h.HandleSQS(context.Background(), body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(store.updates) != 0 {
+		t.Errorf("expected no updates, got %+v", store.updates)
+	}
+	if len(gh.calls) != 0 {
+		t.Errorf("expected no deregister, got %+v", gh.calls)
+	}
+}
+
+func TestHandleSQS_DropsWhenRunnerIDZero(t *testing.T) {
+	store := &fakeStore{}
+	gh := &fakeGitHub{}
+	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+
+	// runner_id == 0 is the defensive case: GitHub did not include a
+	// runner ID in the workflow_job payload. The handler must drop the
+	// message without attempting a Get (avoids a meaningless lookup at
+	// key "0") and without returning an error (the message is ack'd).
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":0,"action":"completed"}`)
 	if err := h.HandleSQS(context.Background(), body); err != nil {
 		t.Fatalf("HandleSQS: %v", err)
 	}
@@ -146,11 +162,11 @@ func TestHandleSQS_UnknownRecordDrops(t *testing.T) {
 }
 
 func TestHandleSQS_DeregisterErrorDoesNotFail(t *testing.T) {
-	store := &fakeStore{get: state.Runner{Status: state.StatusRunning, GitHubRunnerID: 99}}
+	store := &fakeStore{get: state.Runner{ID: "99", Status: state.StatusRunning, GitHubRunnerID: 99, Repository: "owner/repo"}}
 	gh := &fakeGitHub{err: errors.New("network blip")}
 	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
 
-	body := []byte(`{"job_id":1,"repo":"owner/repo","action":"completed"}`)
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
 	if err := h.HandleSQS(context.Background(), body); err != nil {
 		t.Fatalf("HandleSQS: %v", err)
 	}

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -145,7 +145,7 @@ func (c *Cleaner) sweepStalePending(ctx context.Context, runners []state.Runner,
 			next := r.ReEnqueueAttempts + 1
 			msg := &awssqs.ScaleUpMessage{
 				EventAction:       "queued",
-				JobID:             jobIDFromRunner(r),
+				JobID:             r.JobID,
 				RepositoryFull:    r.Repository,
 				Labels:            r.Labels,
 				ReEnqueueAttempts: next,
@@ -252,22 +252,3 @@ func (c *Cleaner) now() time.Time {
 	return time.Now()
 }
 
-// jobIDFromRunner extracts the trailing numeric component of a runner ID
-// encoded as "<repository>#<jobID>". Returns 0 when the ID is malformed.
-// The re-enqueue path needs JobID to populate the new SQS message.
-func jobIDFromRunner(r state.Runner) int64 {
-	id := r.ID
-	for i := len(id) - 1; i >= 0; i-- {
-		if id[i] == '#' {
-			var n int64
-			for _, c := range id[i+1:] {
-				if c < '0' || c > '9' {
-					return 0
-				}
-				n = n*10 + int64(c-'0')
-			}
-			return n
-		}
-	}
-	return 0
-}

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -251,4 +251,3 @@ func (c *Cleaner) now() time.Time {
 	}
 	return time.Now()
 }
-

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -104,7 +104,7 @@ func fixedNow(t time.Time) func() time.Time { return func() time.Time { return t
 // the cutoff (StaleAfter=10m, so 2h ago is unambiguous).
 func stalePending(now time.Time, attempts int) state.Runner {
 	return state.Runner{
-		ID:                "owner/repo#1",
+		ID:                "99",
 		InstanceID:        "i-pending",
 		Repository:        "owner/repo",
 		Labels:            []string{"self-hosted", "linux"},
@@ -113,6 +113,7 @@ func stalePending(now time.Time, attempts int) state.Runner {
 		UpdatedAt:         now.Add(-2 * time.Hour),
 		TTL:               now.Add(24 * time.Hour),
 		GitHubRunnerID:    99,
+		JobID:             1,
 		ReEnqueueAttempts: attempts,
 	}
 }
@@ -121,7 +122,7 @@ func stalePending(now time.Time, attempts int) state.Runner {
 // MaxAge (default 6h, so 12h ago is unambiguous).
 func staleRunning(now time.Time, attempts int) state.Runner {
 	return state.Runner{
-		ID:                "owner/repo#2",
+		ID:                "77",
 		InstanceID:        "i-running",
 		Repository:        "owner/repo",
 		Labels:            []string{"self-hosted", "linux"},
@@ -130,6 +131,7 @@ func staleRunning(now time.Time, attempts int) state.Runner {
 		UpdatedAt:         now.Add(-12 * time.Hour),
 		TTL:               now.Add(24 * time.Hour),
 		GitHubRunnerID:    77,
+		JobID:             2,
 		ReEnqueueAttempts: attempts,
 	}
 }
@@ -450,17 +452,17 @@ func TestCleaner_MultipleRecords_Aggregates(t *testing.T) {
 
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	under := stalePending(now, 0)
-	under.ID = "owner/repo#1"
+	under.ID = "91"
 	under.GitHubRunnerID = 91
 	under.InstanceID = "i-under"
 
 	at := stalePending(now, 2)
-	at.ID = "owner/repo#2"
+	at.ID = "92"
 	at.GitHubRunnerID = 92
 	at.InstanceID = "i-at"
 
 	exhausted := stalePending(now, 3)
-	exhausted.ID = "owner/repo#3"
+	exhausted.ID = "93"
 	exhausted.GitHubRunnerID = 93
 	exhausted.InstanceID = "i-exhausted"
 

--- a/lambda/internal/runner/types.go
+++ b/lambda/internal/runner/types.go
@@ -27,25 +27,34 @@ const (
 // should prefer state.Runner.
 type Runner = state.Runner
 
-// ID derives the canonical runner ID from a repository full name and job ID.
-// The format ("<repo>#<jobID>") matches the pre-refactor DynamoDB primary
-// key so live records continue to round-trip.
-func ID(repository string, jobID int64) string {
-	return repository + "#" + strconv.FormatInt(jobID, 10)
+// IDFromGitHubRunnerID derives the canonical runner ID from a GitHub runner
+// ID returned by the generate-jitconfig endpoint. The format is the decimal
+// string form of the int64; this is the DynamoDB partition key value.
+//
+// JobID and workflow_run_id are intentionally NOT part of the ID — GitHub's
+// JIT contract does not bind a registered runner to either, and earlier
+// "<repo>#<jobID>" encodings produced racy lookups under concurrent jobs.
+// See zettelkasten Projects/jit-runners/specs/2026-05-02-runner-id-realignment-design.md.
+func IDFromGitHubRunnerID(ghRunnerID int64) string {
+	return strconv.FormatInt(ghRunnerID, 10)
 }
 
 // New builds a Runner with sensible defaults: status=pending, LaunchedAt=now,
-// UpdatedAt=now, TTL=now+24h. The runner ID is derived from repository+jobID.
-func New(repository string, jobID int64, instanceID string, labels []string) Runner {
+// UpdatedAt=now, TTL=now+24h. The runner ID is derived from githubRunnerID.
+// jobID and workflowRunID are stored as observability metadata only.
+func New(repository string, githubRunnerID int64, instanceID string, jobID int64, workflowRunID int64, labels []string) Runner {
 	now := time.Now().UTC()
 	return Runner{
-		ID:         ID(repository, jobID),
-		InstanceID: instanceID,
-		Repository: repository,
-		Labels:     labels,
-		Status:     StatusPending,
-		LaunchedAt: now,
-		UpdatedAt:  now,
-		TTL:        now.Add(24 * time.Hour),
+		ID:             IDFromGitHubRunnerID(githubRunnerID),
+		InstanceID:     instanceID,
+		Repository:     repository,
+		Labels:         labels,
+		Status:         StatusPending,
+		LaunchedAt:     now,
+		UpdatedAt:      now,
+		TTL:            now.Add(24 * time.Hour),
+		GitHubRunnerID: githubRunnerID,
+		JobID:          jobID,
+		WorkflowRunID:  workflowRunID,
 	}
 }

--- a/lambda/internal/runner/types_test.go
+++ b/lambda/internal/runner/types_test.go
@@ -1,12 +1,41 @@
 package runner
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
+
+func TestIDFromGitHubRunnerID(t *testing.T) {
+	tests := []struct {
+		ghID int64
+		want string
+	}{
+		{12345, "12345"},
+		{1, "1"},
+		{0, "0"},
+	}
+	for _, tt := range tests {
+		got := IDFromGitHubRunnerID(tt.ghID)
+		if got != tt.want {
+			t.Errorf("IDFromGitHubRunnerID(%d) = %q, want %q", tt.ghID, got, tt.want)
+		}
+	}
+}
 
 func TestNew(t *testing.T) {
-	r := New("org/repo", 123, "i-abc123", []string{"self-hosted", "linux"})
+	r := New("org/repo", 99887766, "i-abc123", 12345, 67890, []string{"self-hosted", "large"})
 
-	if r.ID != "org/repo#123" {
-		t.Errorf("ID = %q, want %q", r.ID, "org/repo#123")
+	if r.ID != "99887766" {
+		t.Errorf("ID = %q, want %q", r.ID, "99887766")
+	}
+	if r.GitHubRunnerID != 99887766 {
+		t.Errorf("GitHubRunnerID = %d, want 99887766", r.GitHubRunnerID)
+	}
+	if r.JobID != 12345 {
+		t.Errorf("JobID = %d, want 12345", r.JobID)
+	}
+	if r.WorkflowRunID != 67890 {
+		t.Errorf("WorkflowRunID = %d, want 67890", r.WorkflowRunID)
 	}
 	if r.InstanceID != "i-abc123" {
 		t.Errorf("InstanceID = %q", r.InstanceID)
@@ -23,22 +52,8 @@ func TestNew(t *testing.T) {
 	if !r.TTL.After(r.LaunchedAt) {
 		t.Error("TTL should be after LaunchedAt")
 	}
-}
-
-func TestID(t *testing.T) {
-	tests := []struct {
-		repo  string
-		jobID int64
-		want  string
-	}{
-		{"org/repo", 123, "org/repo#123"},
-		{"user/project", 0, "user/project#0"},
-		{"a/b", 999999, "a/b#999999"},
-	}
-	for _, tt := range tests {
-		got := ID(tt.repo, tt.jobID)
-		if got != tt.want {
-			t.Errorf("ID(%q, %d) = %q, want %q", tt.repo, tt.jobID, got, tt.want)
-		}
+	// Defensive: ID and GitHubRunnerID must be consistent.
+	if r.ID != strconv.FormatInt(r.GitHubRunnerID, 10) {
+		t.Errorf("ID and GitHubRunnerID inconsistent: ID=%q GitHubRunnerID=%d", r.ID, r.GitHubRunnerID)
 	}
 }

--- a/lambda/internal/state/memstore/memstore.go
+++ b/lambda/internal/state/memstore/memstore.go
@@ -1,0 +1,103 @@
+// Package memstore is an in-memory state.RunnerStore for tests. It is
+// not a build-tagged package; production code never imports it. Keeping
+// it as a regular Go package makes it usable from any *_test.go in the
+// module while incurring zero binary footprint in deployed Lambdas.
+package memstore
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// Store is a thread-safe in-memory state.RunnerStore implementation.
+type Store struct {
+	mu      sync.Mutex
+	records map[string]state.Runner
+}
+
+// Compile-time assertion that Store satisfies state.RunnerStore.
+var _ state.RunnerStore = (*Store)(nil)
+
+// New constructs an empty Store.
+func New() *Store {
+	return &Store{records: map[string]state.Runner{}}
+}
+
+// Put writes a runner record. UpdatedAt is bumped to now to match the
+// dynamo implementation's behavior.
+func (s *Store) Put(_ context.Context, r state.Runner) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if r.ID == "" {
+		return state.ErrNotFound // arbitrary non-nil; tests should not hit this
+	}
+	if r.UpdatedAt.IsZero() || r.UpdatedAt.Before(time.Now()) {
+		r.UpdatedAt = time.Now().UTC()
+	}
+	s.records[r.ID] = r
+	return nil
+}
+
+// Get returns the record at id, or state.ErrNotFound.
+func (s *Store) Get(_ context.Context, id string) (state.Runner, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return state.Runner{}, state.ErrNotFound
+	}
+	return r, nil
+}
+
+// List returns all records optionally filtered by StatusEq.
+func (s *Store) List(_ context.Context, f state.Filter) ([]state.Runner, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []state.Runner
+	for _, r := range s.records {
+		if f.StatusEq != "" && r.Status != f.StatusEq {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// Update applies a partial update to the record at id.
+func (s *Store) Update(_ context.Context, id string, u state.RunnerUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	r, ok := s.records[id]
+	if !ok {
+		return state.ErrNotFound
+	}
+	if u.Status != nil {
+		r.Status = *u.Status
+	}
+	if u.InstanceID != nil {
+		r.InstanceID = *u.InstanceID
+	}
+	if u.GitHubRunnerID != nil {
+		r.GitHubRunnerID = *u.GitHubRunnerID
+	}
+	if u.ReEnqueueAttempts != nil {
+		r.ReEnqueueAttempts = *u.ReEnqueueAttempts
+	}
+	if u.LastAttemptAt != nil {
+		r.LastAttemptAt = *u.LastAttemptAt
+	}
+	r.UpdatedAt = time.Now().UTC()
+	s.records[id] = r
+	return nil
+}
+
+// Delete removes the record at id. Missing keys are not an error.
+func (s *Store) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.records, id)
+	return nil
+}

--- a/lambda/internal/state/memstore/memstore_test.go
+++ b/lambda/internal/state/memstore/memstore_test.go
@@ -1,0 +1,61 @@
+package memstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+func TestPutGetUpdateDelete(t *testing.T) {
+	s := New()
+	ctx := context.Background()
+
+	if _, err := s.Get(ctx, "missing"); !errors.Is(err, state.ErrNotFound) {
+		t.Fatalf("Get missing: err=%v, want ErrNotFound", err)
+	}
+
+	r := state.Runner{ID: "1", Status: state.StatusPending, GitHubRunnerID: 1}
+	if err := s.Put(ctx, r); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	got, err := s.Get(ctx, "1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Status != state.StatusPending {
+		t.Errorf("Status = %q, want %q", got.Status, state.StatusPending)
+	}
+
+	next := state.StatusRunning
+	if err := s.Update(ctx, "1", state.RunnerUpdate{Status: &next}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	got, _ = s.Get(ctx, "1")
+	if got.Status != state.StatusRunning {
+		t.Errorf("Status after Update = %q, want %q", got.Status, state.StatusRunning)
+	}
+
+	if err := s.Delete(ctx, "1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Get(ctx, "1"); !errors.Is(err, state.ErrNotFound) {
+		t.Fatalf("Get after Delete: err=%v, want ErrNotFound", err)
+	}
+}
+
+func TestList_FilterByStatus(t *testing.T) {
+	s := New()
+	ctx := context.Background()
+	_ = s.Put(ctx, state.Runner{ID: "1", Status: state.StatusPending})
+	_ = s.Put(ctx, state.Runner{ID: "2", Status: state.StatusRunning})
+
+	pending, err := s.List(ctx, state.Filter{StatusEq: state.StatusPending})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 || pending[0].ID != "1" {
+		t.Errorf("List(pending) = %+v, want one record id=1", pending)
+	}
+}

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -19,6 +19,13 @@ const (
 var ErrNotFound = errors.New("state: runner not found")
 
 // Runner is the persisted state for a runner managed by jit-runners.
+//
+// ID is the stringified GitHub runner_id returned by
+// generate-jitconfig — the only stable identifier post-registration.
+// Lookups across packages key on this value (see internal/lifecycle
+// and cmd/scaleup). JobID and WorkflowRunID are observability
+// metadata derived from the queue-trigger workflow_job webhook;
+// they are NEVER lookup keys.
 type Runner struct {
 	ID                string
 	InstanceID        string
@@ -29,6 +36,8 @@ type Runner struct {
 	UpdatedAt         time.Time
 	TTL               time.Time
 	GitHubRunnerID    int64
+	JobID             int64
+	WorkflowRunID     int64
 	ReEnqueueAttempts int
 	LastAttemptAt     time.Time
 }

--- a/lambda/internal/webhook/dispatcher_test.go
+++ b/lambda/internal/webhook/dispatcher_test.go
@@ -303,3 +303,46 @@ func TestHandler_Handle_QueuedNonSelfHostedNoPublish(t *testing.T) {
 		t.Errorf("expected no publishes; scaleUp=%d lifecycle=%d", scaleUp.calls, lifeP.calls)
 	}
 }
+
+func TestHandler_Handle_LifecyclePlumbsRunnerID(t *testing.T) {
+	// Synthetic in_progress workflow_job event with runner_id populated.
+	// The dispatcher must publish a lifecycle.Message whose RunnerID
+	// matches the event payload — this guards against accidental drops
+	// of the field during refactors (see issue #52).
+	body := []byte(`{
+		"action": "in_progress",
+		"workflow_job": {
+			"id": 1234,
+			"run_id": 5678,
+			"labels": ["self-hosted","large"],
+			"runner_name": "jit-abc",
+			"runner_id": 99887766,
+			"status": "in_progress"
+		},
+		"repository": {"id": 1, "full_name": "owner/repo", "private": false},
+		"installation": {"id": 42}
+	}`)
+
+	h, _, lifeP := newTestHandler()
+	resp := h.Handle(context.Background(), "workflow_job", sign(body), body)
+	if resp.Status != 202 {
+		t.Fatalf("status = %d, want 202; body=%q", resp.Status, resp.Body)
+	}
+	if lifeP.calls != 1 {
+		t.Fatalf("lifecycle.calls = %d, want 1", lifeP.calls)
+	}
+
+	var got lifecycle.Message
+	if err := json.Unmarshal(lifeP.rawBody, &got); err != nil {
+		t.Fatalf("unmarshal published lifecycle msg: %v", err)
+	}
+	if got.RunnerID != 99887766 {
+		t.Errorf("RunnerID = %d, want 99887766", got.RunnerID)
+	}
+	if got.JobID != 1234 {
+		t.Errorf("JobID = %d, want 1234", got.JobID)
+	}
+	if got.Repo != "owner/repo" {
+		t.Errorf("Repo = %q, want owner/repo", got.Repo)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #52. Realigns jit-runners' DDB persistence and lookup model with GitHub's actual JIT contract: runner identity is the int64 `runner_id` returned by `generate-jitconfig`, not the cosmetic `(repo, job_id)` tuple.

- DDB partition key `runner_id` (string) value changes from `<repo>#<job_id>` to `strconv.FormatInt(githubRunnerID, 10)`.
- Lifecycle handler keys lookups on `workflow_job.runner_id` from the incoming webhook (already plumbed by dispatcher; pinned with a regression test).
- Runner name changes from `jit-<job_id>` to `jit-<uuidv4>` so no future reader assumes a binding GitHub does not enforce.
- `state.Runner` gains observability fields `JobID` and `WorkflowRunID`; neither is a lookup key.
- Single-shot cutover: pre-deploy in-flight records become unreachable from the new lifecycle handler. Scaledown's `Scan`-based reaper handles orphan EC2 + GitHub registrations; DDB TTL clears ghost records within 24h.
- Removes the dead `(repo, job_id)`-keyed idempotency check in scaleup — under the new model each invocation generates a fresh runner_id, so there is no prior record to skip on.

**Targeting \`feat/gcp-support\` (PR #46)**: this fix sits on top of the cloud-agnostic refactor and uses file paths (\`internal/aws/dynamo\`, etc.) that only exist on that branch. It lands as a sub-PR of #46; when #46 merges to main, both reach main together. Per issue #52, #45's GCP work is paused on this fix.

Design spec: \`repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-runner-id-realignment-design.md\` (in the [code-agent-hub](https://github.com/devopsfactory-io/code-agent-hub) zettelkasten).

## What changed (12 commits)

- \`dc17668\` chore(deps): add github.com/google/uuid
- \`4e95b8d\` test(state): add JobID/WorkflowRunID with failing round-trip
- \`91b5134\` feat(dynamo): persist via struct fields, delete parseJobID
- \`e27d205\` refactor(runner): key Runner.ID on GitHub runner_id
- \`f5eb900\` fix(lifecycle): key DDB lookups on workflow_job.runner_id
- \`4e2e5f0\` test(webhook): pin runner_id plumbing into lifecycle.Message
- \`a0bc25c\` feat(scaleup): UUID name + reorder + drop idempotency
- \`19eebf1\` test(state): add memstore for integration tests
- \`b47f6d4\` test(scaleup): integration tests for runner-id keying
- \`6870472\` test(lifecycle): integration test using memstore + fake GitHub
- \`bc30fed\` docs: explain how JIT runners bind to jobs
- \`5f3da5a\` style: gofmt and goimports cleanup

## Test plan

- [x] \`make check\` is green locally — lint clean, vet clean, 121 tests passing across 18 packages.
- [x] Unit tests cover the new lifecycle key shape, the \`RunnerID==0\` defensive drop, and the \`runner.New\` signature change.
- [x] Integration tests in \`lambda/cmd/scaleup\` and \`lambda/cmd/lifecycle\` exercise the flow with the in-memory \`state.RunnerStore\`.
- [ ] After merge into \`feat/gcp-support\`: tag \`v1.0.0-rc.2\`, deploy via \`aws lambda update-function-code\`, then force-push to PR #46 (optionally with concurrent CodeQL re-run) — every queued \`[self-hosted, large]\` job reaches \`in_progress\` then \`completed\`; no stranded \`queued\` after \`StaleThresholdMinutes\`.
- [ ] Spot-check DDB: every record's partition key is a numeric string; \`instance_id\` populated; final \`status=completed\`.

## Out of scope (follow-ups)

- Capacity safeguards (multi-AZ, mixed-instance-type Spot Fleet, per-repo concurrent-runner cap) — see "Capacity model" in the design spec.
- DLQ alerting (deferred from #47).
- ghClient interface refactor for full \`processRecord\` integration coverage.