### PR TITLE
build(makefile): include lifecycle Lambda in build and zip targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,17 @@ lint: ## Run linters
 	cd lambda && golangci-lint run ./...
 
 lambda.build: ## Build Lambda binaries (named bootstrap for provided.al2023 runtime)
-	mkdir -p bin/webhook bin/scaleup bin/scaledown
+	mkdir -p bin/webhook bin/scaleup bin/scaledown bin/lifecycle
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/webhook/bootstrap ./cmd/webhook
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/scaleup/bootstrap ./cmd/scaleup
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/scaledown/bootstrap ./cmd/scaledown
+	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/lifecycle/bootstrap ./cmd/lifecycle
 
 lambda.zip: lambda.build ## Build Lambda zips (bootstrap at root for provided.al2023)
 	cd bin/webhook && zip -qj ../webhook.zip bootstrap
 	cd bin/scaleup && zip -qj ../scaleup.zip bootstrap
 	cd bin/scaledown && zip -qj ../scaledown.zip bootstrap
+	cd bin/lifecycle && zip -qj ../lifecycle.zip bootstrap
 
 lambda.test: ## Run Lambda tests with coverage
 	cd lambda && go test -coverprofile=coverage.out -covermode=atomic ./...


### PR DESCRIPTION
## Summary

The lifecycle Lambda (added in #47) is built by \`.goreleaser.yml\` for tag-driven releases but the Makefile's \`lambda.build\` and \`lambda.zip\` targets still only handle the original three Lambdas (webhook, scaleup, scaledown). Manual local builds — which are needed for non-tag deploys (e.g. cutting an RC without bumping a tag) — therefore produce a partial artifact set.

This adds the missing build + zip steps so \`make lambda.zip\` produces all four artifacts:

\`\`\`
$ ls bin/*.zip
bin/lifecycle.zip  5.1M
bin/scaledown.zip  10.3M
bin/scaleup.zip  10.1M
bin/webhook.zip  4.7M
\`\`\`

## Why now

Caught while doing a manual rc.2 deploy that needed all four artifacts. The lifecycle Lambda has been silently missing from local builds for several weeks; the goreleaser-driven release path masked it.

## Test plan

- [x] \`make lambda.zip\` produces all four bootstrap binaries and zip artifacts.
- [x] Each bootstrap binary is statically linked (\`CGO_ENABLED=0\`) and built for \`linux/amd64\`, matching the existing three.
- [x] Sizes match what \`.goreleaser.yml\` produces for the same commit.
- [ ] CI passes on this PR (also serves as a live smoke test for the v1.0.0-rc.2 deploy of the runner_id realignment fix from #53 — every queued \`[self-hosted, large]\` job should match 1:1 to a fresh JIT runner with a numeric \`runner_id\` DDB key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to compile and package a new lifecycle binary component. The build process now integrates the lifecycle module with existing application binaries, streamlining packaging and deployment. This enhancement improves consistency and simplifies the overall release management process for all application components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->