### PR TITLE
feat(runner): forward diag logs to CloudWatch and detect silent failures

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -560,3 +560,72 @@ The previous form `jit-<job_id>` implied a binding GitHub does not enforce. Futu
 - [REST API: self-hosted runners](https://docs.github.com/en/rest/actions/self-hosted-runners) — `generate-jitconfig` request body.
 - [GitHub Changelog: Just-in-time self-hosted runners (2023-06-02)](https://github.blog/changelog/2023-06-02-github-actions-just-in-time-self-hosted-runners/).
 - Issue [devopsfactory-io/jit-runners#52](https://github.com/devopsfactory-io/jit-runners/issues/52) and the design spec at `repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-runner-id-realignment-design.md`.
+
+## Debugging silent runner failures
+
+A "silent runner failure" is the case where an EC2 spot instance launches, the runner agent exits within seconds, and the instance terminates without ever picking up its assigned job. The first symptom is usually a CI job stuck in `queued` for minutes despite `scaleup` reporting a successful launch.
+
+### Quick check: did silent failures fire?
+
+```bash
+aws cloudwatch get-metric-statistics \
+  --namespace JitRunners/RunnerAgent \
+  --metric-name SilentFailures \
+  --start-time $(date -u -v-1H +%FT%TZ) \
+  --end-time $(date -u +%FT%TZ) \
+  --period 300 \
+  --statistics Sum
+```
+
+A non-zero `Sum` means at least one runner emitted `JIT_NO_JOB_PICKUP` in the past hour.
+
+### Find the affected runner_id
+
+```bash
+aws logs filter-log-events \
+  --log-group-name /jit-runners/userdata \
+  --filter-pattern '"JIT_NO_JOB_PICKUP"' \
+  --start-time $(($(date +%s) - 3600))000 \
+  --query 'events[].{ts:timestamp,msg:message}' \
+  --output table
+```
+
+Each match contains the `runner_id` and the `runtime` in seconds.
+
+### Inspect the runner-agent diag logs
+
+The CloudWatch agent ships `_diag/Runner_*.log` and `_diag/Worker_*.log` to `/jit-runners/runner-agent`, stream `<runner_id>/<instance_id>`:
+
+```bash
+aws logs tail /jit-runners/runner-agent --since 1h --filter-pattern '"<runner_id>"'
+```
+
+Or open the AWS Console: CloudWatch → Log groups → `/jit-runners/runner-agent` → log stream prefixed `<runner_id>/`.
+
+### Increase verbosity for the next runners
+
+Flip the SSM toggle to `debug`. Effect is visible on the next-but-one scaleup invocation (≤30s due to the in-process cache):
+
+```bash
+aws ssm put-parameter \
+  --name /jit-runners/runner-log-level \
+  --value debug \
+  --overwrite
+```
+
+Reproduce the issue, inspect the debug-level log lines (look for `##[debug]` markers in `Worker_*.log`), then revert:
+
+```bash
+aws ssm put-parameter \
+  --name /jit-runners/runner-log-level \
+  --value info \
+  --overwrite
+```
+
+### Reproducing a silent failure for testing
+
+To exercise the silent-failure path on demand without a real workload:
+
+1. Generate a JIT config: `gh api -X POST repos/<owner>/<repo>/actions/runners/generate-jitconfig -f name=test -f labels[]=self-hosted -F runner_group_id=1`. Capture the `runner.id`.
+2. Immediately revoke it: `gh api -X DELETE repos/<owner>/<repo>/actions/runners/<runner.id>`.
+3. Send a synthetic SQS message to the scaleup queue carrying the revoked `encoded_jit_config`. A new spot instance launches, registers nothing, exits, and emits `JIT_NO_JOB_PICKUP`.

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -187,6 +187,20 @@ Resources:
                 Condition:
                   StringEquals:
                     "ec2:ResourceTag/managed-by": jit-runners
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:DescribeLogStreams
+                Resource:
+                  - !GetAtt RunnerAgentLogGroup.Arn
+                  - !GetAtt RunnerUserdataLogGroup.Arn
+                  - !Sub "${RunnerAgentLogGroup.Arn}:log-stream:*"
+                  - !Sub "${RunnerUserdataLogGroup.Arn}:log-stream:*"
 
   RunnerInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -339,6 +353,13 @@ Resources:
                 Resource:
                   - !Ref WebhookSecretArn
                   - !Ref PrivateKeySecretArn
+        - PolicyName: SSMReadRunnerLogLevel
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: ssm:GetParameter
+                Resource: !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/jit-runners/runner-log-level"
 
   ScaleUpFunction:
     Type: AWS::Lambda::Function
@@ -556,6 +577,44 @@ Resources:
       Target:
         Arn: !GetAtt ScaleDownFunction.Arn
         RoleArn: !GetAtt SchedulerRole.Arn
+
+  # --- Diagnostic logging (issue #55) ---
+
+  RunnerAgentLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /jit-runners/runner-agent
+      RetentionInDays: 14
+
+  RunnerUserdataLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /jit-runners/userdata
+      RetentionInDays: 14
+
+  SilentFailureMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    DependsOn: RunnerUserdataLogGroup
+    Properties:
+      LogGroupName: /jit-runners/userdata
+      FilterPattern: "JIT_NO_JOB_PICKUP"
+      MetricTransformations:
+        - MetricName: SilentFailures
+          MetricNamespace: JitRunners/RunnerAgent
+          MetricValue: "1"
+          DefaultValue: 0
+
+  RunnerLogLevelParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /jit-runners/runner-log-level
+      Type: String
+      Value: info
+      AllowedPattern: "^(info|debug)$"
+      Description: |
+        Controls runner-agent verbosity. Set to "debug" while
+        investigating; flip back to "info" afterward. Read by the
+        scaleup Lambda on each invocation (30s in-process cache).
 
 Outputs:
   WebhookUrl:

--- a/infra/packer/scripts/08-cloudwatch-agent.sh
+++ b/infra/packer/scripts/08-cloudwatch-agent.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -euo pipefail
+
+# jit-runners: install and configure the AWS CloudWatch agent.
+#
+# The agent tails the runner-agent diagnostic logs and the userdata
+# script's stdout; the userdata starts the agent at boot AFTER exporting
+# RUNNER_ID so the stream name resolves to <runner_id>/<instance_id>.
+
+echo "=== jit-runners: installing amazon-cloudwatch-agent ==="
+sudo dnf install -y https://amazoncloudwatch-agent.s3.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm
+
+echo "=== jit-runners: writing cloudwatch agent config ==="
+sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null <<'EOF'
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/home/runner/actions-runner/_diag/Runner_*.log",
+            "log_group_name": "/jit-runners/runner-agent",
+            "log_stream_name": "${RUNNER_ID}/{instance_id}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%SZ",
+            "retention_in_days": 14
+          },
+          {
+            "file_path": "/home/runner/actions-runner/_diag/Worker_*.log",
+            "log_group_name": "/jit-runners/runner-agent",
+            "log_stream_name": "${RUNNER_ID}/{instance_id}",
+            "timestamp_format": "%Y-%m-%d %H:%M:%SZ",
+            "retention_in_days": 14
+          },
+          {
+            "file_path": "/var/log/jit-runner-userdata.log",
+            "log_group_name": "/jit-runners/userdata",
+            "log_stream_name": "${RUNNER_ID}/{instance_id}",
+            "retention_in_days": 14
+          }
+        ]
+      }
+    },
+    "force_flush_interval": 5
+  }
+}
+EOF
+
+echo "=== jit-runners: enabling cloudwatch agent (deferred start) ==="
+# Enable but do NOT start now. Userdata starts the unit AFTER exporting
+# RUNNER_ID so the stream-name placeholder resolves.
+sudo systemctl enable amazon-cloudwatch-agent
+
+echo "=== jit-runners: cloudwatch agent installed ==="

--- a/infra/packer/scripts/setup-runner.sh
+++ b/infra/packer/scripts/setup-runner.sh
@@ -24,6 +24,7 @@ for script in \
   "${SCRIPT_DIR}/03-languages.sh" \
   "${SCRIPT_DIR}/04-cloud-tools.sh" \
   "${SCRIPT_DIR}/05-cli-tools.sh" \
+  "${SCRIPT_DIR}/08-cloudwatch-agent.sh" \
   "${SCRIPT_DIR}/07-cleanup.sh"; do
 
   echo ""

--- a/infra/terraform/diagnostics.tf
+++ b/infra/terraform/diagnostics.tf
@@ -1,0 +1,84 @@
+# Diagnostic logging (issue #55).
+#
+# Mirrors infra/cloudformation/template.yaml additions in the same change set.
+
+resource "aws_cloudwatch_log_group" "runner_agent" {
+  name              = "/jit-runners/runner-agent"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_group" "runner_userdata" {
+  name              = "/jit-runners/userdata"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_log_metric_filter" "silent_failure" {
+  name           = "JitNoJobPickup"
+  log_group_name = aws_cloudwatch_log_group.runner_userdata.name
+  pattern        = "JIT_NO_JOB_PICKUP"
+
+  metric_transformation {
+    name          = "SilentFailures"
+    namespace     = "JitRunners/RunnerAgent"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_ssm_parameter" "runner_log_level" {
+  name        = "/jit-runners/runner-log-level"
+  type        = "String"
+  value       = "info"
+  description = "Runner-agent verbosity (info|debug). Read by scaleup on each invocation."
+
+  lifecycle {
+    # Operators flip this manually during incidents (aws ssm put-parameter).
+    # Routine `terraform apply` must NOT silently revert their change.
+    ignore_changes = [value]
+  }
+}
+
+# RunnerRole — append CloudWatch Logs permissions for the new groups.
+# Defined as a separate inline policy attached to the existing role, so it
+# coexists with the SelfTerminate policy already in ec2.tf.
+resource "aws_iam_role_policy" "runner_cloudwatch_logs" {
+  name = "${aws_iam_role.runner.name}-cw-logs"
+  role = aws_iam_role.runner.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams",
+        ]
+        Resource = [
+          aws_cloudwatch_log_group.runner_agent.arn,
+          aws_cloudwatch_log_group.runner_userdata.arn,
+          "${aws_cloudwatch_log_group.runner_agent.arn}:log-stream:*",
+          "${aws_cloudwatch_log_group.runner_userdata.arn}:log-stream:*",
+        ]
+      },
+    ]
+  })
+}
+
+# ScaleUpLambdaRole — read /jit-runners/runner-log-level from SSM.
+resource "aws_iam_role_policy" "scaleup_ssm_read_log_level" {
+  name = "${aws_iam_role.scaleup_lambda.name}-ssm-log-level"
+  role = aws_iam_role.scaleup_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = aws_ssm_parameter.runner_log_level.arn
+      },
+    ]
+  })
+}

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -19,8 +19,8 @@ import (
 
 	awsdynamo "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/dynamo"
 	awsec2 "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ec2"
-	awsssm "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ssm"
 	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
+	awsssm "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ssm"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
@@ -104,7 +104,11 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 		return fmt.Errorf("generate JIT config: %w", err)
 	}
 
-	runnerLogLevel, _ := ssmLoader.Get(ctx, runnerLogLevelParam, runnerLogLevelDefault)
+	runnerLogLevel, ssmErr := ssmLoader.Get(ctx, runnerLogLevelParam, runnerLogLevelDefault)
+	if ssmErr != nil {
+		// Loader's contract guarantees fallback on errors; defensively log.
+		log.Printf("ssm: get runner log level: %v (using fallback)", ssmErr)
+	}
 
 	// Persist a pending record keyed on the GitHub runner_id BEFORE
 	// launching the EC2 instance so scaledown's stale-pending sweep can

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -10,13 +10,16 @@ import (
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	awsec2sdk "github.com/aws/aws-sdk-go-v2/service/ec2"
+	awssdkssm "github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/google/uuid"
 
 	awsdynamo "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/dynamo"
 	awsec2 "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ec2"
+	awsssm "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/ssm"
 	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
@@ -32,6 +35,15 @@ var (
 	cfgOnce sync.Once
 	appCfg  *appconfig.Config
 	cfgErr  error
+
+	ssmLoaderOnce sync.Once
+	ssmLoaderRef  *awsssm.Loader
+)
+
+const (
+	runnerLogLevelParam   = "/jit-runners/runner-log-level"
+	runnerLogLevelDefault = "info"
+	ssmCacheTTL           = 30 * time.Second
 )
 
 func main() {
@@ -50,6 +62,8 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 		return fmt.Errorf("load AWS config: %w", err)
 	}
 
+	ssmLoader := getSSMLoader(awsCfg)
+
 	launcher := awsec2.NewLauncher(awsec2sdk.NewFromConfig(awsCfg), awsec2.LauncherOptions{
 		SecurityGroupID:    cfg.SecurityGroupID,
 		IAMInstanceProfile: cfg.IAMInstanceProfile,
@@ -57,7 +71,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 	store := awsdynamo.NewStore(dynamodb.NewFromConfig(awsCfg), cfg.TableName)
 
 	for _, record := range sqsEvent.Records {
-		if err := processRecord(ctx, cfg, launcher, store, record); err != nil {
+		if err := processRecord(ctx, cfg, launcher, store, ssmLoader, record); err != nil {
 			log.Printf("error processing record %s: %v", record.MessageId, err)
 			return err
 		}
@@ -65,7 +79,7 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) error {
 	return nil
 }
 
-func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.Launcher, store state.RunnerStore, record events.SQSMessage) error {
+func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.Launcher, store state.RunnerStore, ssmLoader *awsssm.Loader, record events.SQSMessage) error {
 	msg, err := awssqs.ParseMessage(record.Body)
 	if err != nil {
 		log.Printf("parse SQS message: %v", err)
@@ -90,6 +104,8 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 		return fmt.Errorf("generate JIT config: %w", err)
 	}
 
+	runnerLogLevel, _ := ssmLoader.Get(ctx, runnerLogLevelParam, runnerLogLevelDefault)
+
 	// Persist a pending record keyed on the GitHub runner_id BEFORE
 	// launching the EC2 instance so scaledown's stale-pending sweep can
 	// reap orphans if scaleup itself dies between RunInstances and the
@@ -111,8 +127,10 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 		runnerVersion = defaultRunnerVersion
 	}
 	userData, err := awsec2.GenerateUserData(&awsec2.UserDataParams{
-		RunnerVersion: runnerVersion,
-		JITConfig:     jitCfg.EncodedJIT,
+		RunnerVersion:  runnerVersion,
+		JITConfig:      jitCfg.EncodedJIT,
+		RunnerID:       jitCfg.Runner.ID,
+		RunnerLogLevel: runnerLogLevel,
 	})
 	if err != nil {
 		markLaunchFailed(ctx, ghClient, store, msg, pending.ID, jitCfg.Runner.ID)
@@ -223,6 +241,13 @@ func loadConfig(ctx context.Context) (*appconfig.Config, error) {
 		appCfg, cfgErr = appconfig.Load(ctx)
 	})
 	return appCfg, cfgErr
+}
+
+func getSSMLoader(awsCfg aws.Config) *awsssm.Loader {
+	ssmLoaderOnce.Do(func() {
+		ssmLoaderRef = awsssm.New(awssdkssm.NewFromConfig(awsCfg), ssmCacheTTL)
+	})
+	return ssmLoaderRef
 }
 
 func init() {

--- a/lambda/cmd/scaleup/main_integration_test.go
+++ b/lambda/cmd/scaleup/main_integration_test.go
@@ -46,7 +46,7 @@ func TestProcessRecord_ParseFailureIsNoOp(t *testing.T) {
 	store := memstore.New()
 
 	rec := events.SQSMessage{Body: "{not json"}
-	if err := processRecord(context.Background(), cfg, launcher, store, rec); err != nil {
+	if err := processRecord(context.Background(), cfg, launcher, store, nil, rec); err != nil {
 		t.Fatalf("processRecord on bad JSON should return nil to avoid retry; got %v", err)
 	}
 	if len(launcher.launches) != 0 {

--- a/lambda/go.mod
+++ b/lambda/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 require (
 	github.com/aws/aws-lambda-go v1.54.0
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.37
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1
@@ -18,16 +18,17 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.32.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
-	github.com/aws/smithy-go v1.24.2 // indirect
+	github.com/aws/smithy-go v1.25.1 // indirect
 )

--- a/lambda/go.sum
+++ b/lambda/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFh
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
 github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/config v1.32.14 h1:opVIRo/ZbbI8OIqSOKmpFaY7IwfFUOCCXBsUpJOwDdI=
 github.com/aws/aws-sdk-go-v2/config v1.32.14/go.mod h1:U4/V0uKxh0Tl5sxmCBZ3AecYny4UNlVmObYjKuuaiOo=
 github.com/aws/aws-sdk-go-v2/credentials v1.19.14 h1:n+UcGWAIZHkXzYt87uMFBv/l8THYELoX6gVcUvgl6fI=
@@ -12,8 +14,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 h1:NUS3K4BTDArQqNu2ih7yeD
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21/go.mod h1:YWNWJQNjKigKY1RHVJCuupeWDrrHjRqHm0N9rdrWzYI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.57.1 h1:Vk+a1j2pXZHkkYqHmEdpwe8eX6NDtFSBGfzuauMEWYQ=
@@ -34,6 +40,8 @@ github.com/aws/aws-sdk-go-v2/service/signin v1.0.9 h1:QKZH0S178gCmFEgst8hN0mCX1K
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.9/go.mod h1:7yuQJoT+OoH8aqIxw9vwF+8KpvLZ8AWmvmUWHsGQZvI=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25 h1:8Bv3TQ1Cob6HLlpUbAnWxeHhAkYScJO9RIHh2WPXaxw=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.25/go.mod h1:eDstEbM0OEnBUnNQxIA7j74Jy61cCU1S4EMlCtdMwzs=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6 h1:0LPJjbSNEDHidGOXa0LfvSVbdn9/GdlJUQTgE0kFpso=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.68.6/go.mod h1:SrZAopBP5/lyQ6NBVXKlRp8wPIXhzBCZU98sEozmv8Y=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15 h1:lFd1+ZSEYJZYvv9d6kXzhkZu07si3f+GQ1AaYwa2LUM=
 github.com/aws/aws-sdk-go-v2/service/sso v1.30.15/go.mod h1:WSvS1NLr7JaPunCXqpJnWk1Bjo7IxzZXrZi1QQCkuqM=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 h1:dzztQ1YmfPrxdrOiuZRMF6fuOwWlWpD2StNLTceKpys=
@@ -42,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBU
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=

--- a/lambda/internal/aws/ec2/userdata.go
+++ b/lambda/internal/aws/ec2/userdata.go
@@ -7,12 +7,22 @@ import (
 	"text/template"
 )
 
+// silentFailureThresholdSecs is the wall-clock budget (seconds) below which a
+// run.sh exit with no Worker file written is treated as a silent failure
+// and emits JIT_NO_JOB_PICKUP. The default 30 is sized below the observed
+// minimum healthy job duration (lint job from PR #54: 84s pickup→complete).
+// Retune based on healthy-pickup p99 latency once we have data.
+const silentFailureThresholdSecs = 30
+
 const userdataTemplate = `#!/bin/bash
-set -euo pipefail
+set -uo pipefail
 
 RUNNER_VERSION="{{.RunnerVersion}}"
 JIT_CONFIG="{{.JITConfig}}"
-
+export RUNNER_ID={{.RunnerID}}
+{{if eq .RunnerLogLevel "debug"}}export ACTIONS_RUNNER_DEBUG=true
+export ACTIONS_STEP_DEBUG=true
+{{end}}
 # IMDSv2 token-based metadata access
 IMDS_TOKEN=$(curl -sf -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 300")
 INSTANCE_ID=$(curl -sf -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" http://169.254.169.254/latest/meta-data/instance-id)
@@ -20,6 +30,7 @@ REGION=$(curl -sf -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" http://169.254.16
 
 echo "=== jit-runners: configuring ephemeral runner on ${INSTANCE_ID} (${REGION}) ==="
 echo "Runner version: ${RUNNER_VERSION}"
+echo "Runner ID: ${RUNNER_ID}"
 
 if [ -f /opt/jit-runner-prebaked ]; then
     PREBAKED_VERSION=$(cat /opt/jit-runner-prebaked)
@@ -52,11 +63,42 @@ else
     chown -R runner:runner /home/runner/actions-runner
 fi
 
-# Start the runner with JIT config (runs one job, then exits)
+# Start the CloudWatch agent so runner-agent _diag/* logs and this script's
+# stdout (via tee) ship to CloudWatch even if run.sh exits within seconds.
+# RUNNER_ID is read by the baked config at /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json.
+echo "=== jit-runners: starting CloudWatch agent ==="
+if ! systemctl start amazon-cloudwatch-agent; then
+    echo "WARN: amazon-cloudwatch-agent failed to start; continuing without remote logs"
+fi
+
+# Start the runner with JIT config (runs one job, then exits).
 echo "Starting runner with JIT config..."
-su - runner -c "cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'" 2>&1
-RUNNER_EXIT=$?
-echo "=== jit-runners: runner exited with code ${RUNNER_EXIT} ==="
+START_TIME=$(date +%s)
+set +e
+su - runner -c "cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'" 2>&1 | tee /var/log/jit-runner-userdata.log
+RUNNER_EXIT=${PIPESTATUS[0]}
+set -e
+END_TIME=$(date +%s)
+RUNTIME_SECS=$((END_TIME - START_TIME))
+echo "=== jit-runners: runner exited with code ${RUNNER_EXIT} after ${RUNTIME_SECS}s ==="
+
+# Detect silent-failure: runner returned 0 but never wrote a Worker_*.log,
+# and the wall-clock budget is below the threshold. Worker file presence is
+# the load-bearing signal because the runner forks a worker per job.
+JOB_PICKED_UP=1
+if compgen -G "/home/runner/actions-runner/_diag/Worker_*.log" >/dev/null; then
+    JOB_PICKED_UP=0
+fi
+if [ "${RUNNER_EXIT}" -eq 0 ] && [ "${RUNTIME_SECS}" -lt {{.SilentFailureThresholdSecs}} ] && [ "${JOB_PICKED_UP}" -ne 0 ]; then
+    MSG="JIT_NO_JOB_PICKUP runner_id={{.RunnerID}} runtime=${RUNTIME_SECS}s"
+    echo "${MSG}"
+    logger -t jit-runners "${MSG}"
+    echo "${MSG}" >> /var/log/jit-runner-userdata.log
+fi
+
+# Sleep so the CloudWatch agent (default 1s polling) can ship the last lines
+# before the instance terminates.
+sleep 5
 
 echo "=== jit-runners: terminating instance ==="
 aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${REGION}" || true
@@ -66,6 +108,14 @@ aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${REGION}"
 type UserDataParams struct {
 	RunnerVersion string
 	JITConfig     string
+	// RunnerID is the GitHub-assigned int64 runner_id (the partition key
+	// for the per-runner DynamoDB record). Plumbed into the userdata so the
+	// CloudWatch agent can stamp it into the log stream name.
+	RunnerID int64
+	// RunnerLogLevel is "info" or "debug". When "debug", the userdata
+	// exports ACTIONS_RUNNER_DEBUG=true and ACTIONS_STEP_DEBUG=true so the
+	// runner agent emits debug-level logs. Empty string is treated as "info".
+	RunnerLogLevel string
 }
 
 // GenerateUserData renders the user-data script and returns it base64-encoded.
@@ -76,6 +126,9 @@ func GenerateUserData(params *UserDataParams) (string, error) {
 	if params.JITConfig == "" {
 		return "", fmt.Errorf("JIT config is required")
 	}
+	if params.RunnerID == 0 {
+		return "", fmt.Errorf("runner id is required")
+	}
 
 	tmpl, err := template.New("userdata").Parse(userdataTemplate)
 	if err != nil {
@@ -83,8 +136,15 @@ func GenerateUserData(params *UserDataParams) (string, error) {
 	}
 
 	var buf bytes.Buffer
-	if err := tmpl.Execute(&buf, params); err != nil {
-		return "", fmt.Errorf("execute userdata template: %w", err)
+	data := struct {
+		*UserDataParams
+		SilentFailureThresholdSecs int
+	}{
+		UserDataParams:             params,
+		SilentFailureThresholdSecs: silentFailureThresholdSecs,
+	}
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", fmt.Errorf("execute user-data template: %w", err)
 	}
 
 	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil

--- a/lambda/internal/aws/ec2/userdata_test.go
+++ b/lambda/internal/aws/ec2/userdata_test.go
@@ -12,18 +12,28 @@ func TestGenerateUserData(t *testing.T) {
 		params    *UserDataParams
 		wantErr   bool
 		wantParts []string
+		notParts  []string
 	}{
 		{
-			name: "valid params",
+			name: "valid params info-level",
 			params: &UserDataParams{
-				RunnerVersion: "2.321.0",
-				JITConfig:     "encoded-jit-config-string",
+				RunnerVersion:  "2.321.0",
+				JITConfig:      "encoded-jit-config-string",
+				RunnerID:       42,
+				RunnerLogLevel: "info",
 			},
 			wantParts: []string{
 				"#!/bin/bash",
 				"RUNNER_VERSION=\"2.321.0\"",
 				"JIT_CONFIG=\"encoded-jit-config-string\"",
+				"export RUNNER_ID=42",
+				"systemctl start amazon-cloudwatch-agent",
 				"./run.sh --jitconfig",
+				"tee /var/log/jit-runner-userdata.log",
+				"RUNTIME_SECS",
+				"-lt 30",
+				"JIT_NO_JOB_PICKUP runner_id=42",
+				"sleep 5",
 				"terminate-instances",
 				"/opt/jit-runner-prebaked",
 				"dnf install",
@@ -33,20 +43,67 @@ func TestGenerateUserData(t *testing.T) {
 				"jq",
 				"rm -f runner.tar.gz",
 			},
+			notParts: []string{
+				"export ACTIONS_RUNNER_DEBUG=true",
+				"export ACTIONS_STEP_DEBUG=true",
+			},
+		},
+		{
+			name: "valid params debug-level",
+			params: &UserDataParams{
+				RunnerVersion:  "2.321.0",
+				JITConfig:      "encoded-jit-config-string",
+				RunnerID:       7,
+				RunnerLogLevel: "debug",
+			},
+			wantParts: []string{
+				"export RUNNER_ID=7",
+				"export ACTIONS_RUNNER_DEBUG=true",
+				"export ACTIONS_STEP_DEBUG=true",
+				"JIT_NO_JOB_PICKUP runner_id=7",
+			},
 		},
 		{
 			name: "missing runner version",
 			params: &UserDataParams{
-				JITConfig: "some-config",
+				JITConfig:      "some-config",
+				RunnerID:       1,
+				RunnerLogLevel: "info",
 			},
 			wantErr: true,
 		},
 		{
 			name: "missing JIT config",
 			params: &UserDataParams{
-				RunnerVersion: "2.321.0",
+				RunnerVersion:  "2.321.0",
+				RunnerID:       1,
+				RunnerLogLevel: "info",
 			},
 			wantErr: true,
+		},
+		{
+			name: "missing runner id",
+			params: &UserDataParams{
+				RunnerVersion:  "2.321.0",
+				JITConfig:      "some-config",
+				RunnerLogLevel: "info",
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty runner log level defaults to no debug",
+			params: &UserDataParams{
+				RunnerVersion: "2.321.0",
+				JITConfig:     "some-config",
+				RunnerID:      99,
+			},
+			wantParts: []string{
+				"export RUNNER_ID=99",
+			},
+			notParts: []string{
+				"export ACTIONS_RUNNER_DEBUG=true",
+				"export ACTIONS_STEP_DEBUG=true",
+			},
 		},
 	}
 
@@ -62,19 +119,27 @@ func TestGenerateUserData(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-
-			// Decode base64 and verify content.
-			decoded, err := base64.StdEncoding.DecodeString(got)
-			if err != nil {
-				t.Fatalf("base64 decode: %v", err)
+			decoded, derr := base64.StdEncoding.DecodeString(got)
+			if derr != nil {
+				t.Fatalf("decode base64: %v", derr)
 			}
-			script := string(decoded)
-
-			for _, part := range tt.wantParts {
-				if !strings.Contains(script, part) {
-					t.Errorf("user-data missing %q", part)
+			body := string(decoded)
+			for _, want := range tt.wantParts {
+				if !strings.Contains(body, want) {
+					t.Errorf("rendered userdata missing %q\n--- body ---\n%s", want, body)
+				}
+			}
+			for _, notWant := range tt.notParts {
+				if strings.Contains(body, notWant) {
+					t.Errorf("rendered userdata contains forbidden %q", notWant)
 				}
 			}
 		})
+	}
+}
+
+func TestSilentFailureThresholdConstant(t *testing.T) {
+	if silentFailureThresholdSecs != 30 {
+		t.Errorf("silentFailureThresholdSecs = %d, want 30 (changing this value rolls over the JIT_NO_JOB_PICKUP semantics; coordinate with the operator runbook)", silentFailureThresholdSecs)
 	}
 }

--- a/lambda/internal/aws/ssm/loader.go
+++ b/lambda/internal/aws/ssm/loader.go
@@ -1,0 +1,92 @@
+// Package ssm is a thin AWS Systems Manager Parameter Store reader with a
+// TTL cache. Production callers use it for low-frequency runtime toggles
+// such as /jit-runners/runner-log-level.
+package ssm
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// API abstracts the SSM GetParameter operation for testing. The real
+// *ssm.Client satisfies this interface.
+type API interface {
+	GetParameter(ctx context.Context, in *ssm.GetParameterInput, opts ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+}
+
+// Loader fetches SSM parameters with a TTL cache. Use one Loader per process;
+// the cache is keyed by parameter name and is safe for concurrent callers.
+type Loader struct {
+	client API
+	ttl    time.Duration
+
+	mu      sync.Mutex
+	entries map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	value    string
+	expires  time.Time
+	hasValue bool
+}
+
+// New constructs a Loader. ttl is the cache window for successful reads.
+// A ttl of zero disables caching.
+func New(client API, ttl time.Duration) *Loader {
+	return &Loader{
+		client:  client,
+		ttl:     ttl,
+		entries: map[string]cacheEntry{},
+	}
+}
+
+// Get returns the parameter's string value or fallback when the parameter
+// does not exist or the API call fails. When the cache holds a non-expired
+// hit, it is returned directly without an API call. When the cache has an
+// expired hit and the API call fails, the previous value is returned (last-
+// known-good) so transient throttles do not collapse to fallback. A first-
+// call API failure returns fallback.
+func (l *Loader) Get(ctx context.Context, name string, fallback string) (string, error) {
+	now := time.Now()
+
+	l.mu.Lock()
+	if e, ok := l.entries[name]; ok && e.hasValue && now.Before(e.expires) {
+		l.mu.Unlock()
+		return e.value, nil
+	}
+	prev := l.entries[name]
+	l.mu.Unlock()
+
+	out, err := l.client.GetParameter(ctx, &ssm.GetParameterInput{Name: aws.String(name)})
+	if err != nil {
+		var notFound *types.ParameterNotFound
+		if errors.As(err, &notFound) {
+			log.Printf("ssm: parameter %s missing, defaulting to %q", name, fallback)
+			return fallback, nil
+		}
+		if prev.hasValue {
+			log.Printf("ssm: get %s failed (%v), returning last cached value %q", name, err, prev.value)
+			return prev.value, nil
+		}
+		log.Printf("ssm: get %s failed (%v) on cold cache, defaulting to %q", name, err, fallback)
+		return fallback, nil
+	}
+	value := aws.ToString(out.Parameter.Value)
+
+	l.mu.Lock()
+	l.entries[name] = cacheEntry{
+		value:    value,
+		expires:  now.Add(l.ttl),
+		hasValue: true,
+	}
+	l.mu.Unlock()
+
+	return value, nil
+}

--- a/lambda/internal/aws/ssm/loader_test.go
+++ b/lambda/internal/aws/ssm/loader_test.go
@@ -1,0 +1,135 @@
+package ssm
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// fakeSSM is a minimal stand-in for *ssm.Client that records calls and
+// returns scripted responses keyed by parameter name.
+type fakeSSM struct {
+	calls    atomic.Int32
+	values   map[string]string // name -> value to return
+	notFound map[string]bool   // name -> simulate ParameterNotFound
+	apiErr   error             // returned for every call when set
+}
+
+func (f *fakeSSM) GetParameter(_ context.Context, in *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	f.calls.Add(1)
+	if f.apiErr != nil {
+		return nil, f.apiErr
+	}
+	name := aws.ToString(in.Name)
+	if f.notFound[name] {
+		return nil, &types.ParameterNotFound{}
+	}
+	v, ok := f.values[name]
+	if !ok {
+		return nil, &types.ParameterNotFound{}
+	}
+	return &ssm.GetParameterOutput{
+		Parameter: &types.Parameter{
+			Name:  aws.String(name),
+			Value: aws.String(v),
+		},
+	}, nil
+}
+
+func TestLoader_GetCachesValue(t *testing.T) {
+	f := &fakeSSM{values: map[string]string{"/jit-runners/runner-log-level": "debug"}}
+	l := New(f, 100*time.Millisecond)
+	ctx := context.Background()
+
+	got, err := l.Get(ctx, "/jit-runners/runner-log-level", "info")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "debug" {
+		t.Errorf("first Get: got %q, want debug", got)
+	}
+
+	got, _ = l.Get(ctx, "/jit-runners/runner-log-level", "info")
+	if got != "debug" {
+		t.Errorf("cached Get: got %q, want debug", got)
+	}
+	if c := f.calls.Load(); c != 1 {
+		t.Errorf("API calls = %d, want 1 (cache miss only)", c)
+	}
+}
+
+func TestLoader_GetRefetchesAfterTTL(t *testing.T) {
+	f := &fakeSSM{values: map[string]string{"/jit-runners/runner-log-level": "debug"}}
+	l := New(f, 50*time.Millisecond)
+	ctx := context.Background()
+
+	if _, err := l.Get(ctx, "/jit-runners/runner-log-level", "info"); err != nil {
+		t.Fatalf("first Get: %v", err)
+	}
+	time.Sleep(80 * time.Millisecond)
+	f.values["/jit-runners/runner-log-level"] = "info"
+	got, err := l.Get(ctx, "/jit-runners/runner-log-level", "info")
+	if err != nil {
+		t.Fatalf("post-TTL Get: %v", err)
+	}
+	if got != "info" {
+		t.Errorf("post-TTL Get: got %q, want info", got)
+	}
+	if c := f.calls.Load(); c != 2 {
+		t.Errorf("API calls = %d, want 2 (initial + refetch)", c)
+	}
+}
+
+func TestLoader_GetMissingFallsBackToDefault(t *testing.T) {
+	f := &fakeSSM{notFound: map[string]bool{"/missing": true}}
+	l := New(f, time.Minute)
+	ctx := context.Background()
+
+	got, err := l.Get(ctx, "/missing", "fallback-value")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "fallback-value" {
+		t.Errorf("got %q, want fallback-value", got)
+	}
+}
+
+func TestLoader_GetAPIErrorFallsBackWhenNoCache(t *testing.T) {
+	f := &fakeSSM{apiErr: errors.New("throttle")}
+	l := New(f, time.Minute)
+
+	got, err := l.Get(context.Background(), "/whatever", "default")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "default" {
+		t.Errorf("got %q, want default", got)
+	}
+}
+
+func TestLoader_GetAPIErrorReturnsLastCachedValue(t *testing.T) {
+	f := &fakeSSM{values: map[string]string{"/x": "first"}}
+	l := New(f, 50*time.Millisecond)
+	ctx := context.Background()
+
+	if _, err := l.Get(ctx, "/x", "default"); err != nil {
+		t.Fatalf("warm-up Get: %v", err)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+	f.apiErr = errors.New("throttle")
+
+	got, err := l.Get(ctx, "/x", "default")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "first" {
+		t.Errorf("got %q, want first (last cached value)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #55. Ships the observability needed to diagnose silent runner-agent failures (the failure mode that surfaced during the v1.0.0-rc.2 verification on PR #54), plus an SSM-driven runner log-level toggle.

- AWS CloudWatch agent baked into the AMI (\`infra/packer/scripts/08-cloudwatch-agent.sh\`).
- Userdata exports \`RUNNER_ID\` and starts the agent before \`run.sh\`; tees output to \`/var/log/jit-runner-userdata.log\`; emits \`JIT_NO_JOB_PICKUP\` when run.sh exits 0 in <30s without a Worker file; sleeps 5s before terminate to flush.
- Two new log groups (\`/jit-runners/runner-agent\`, \`/jit-runners/userdata\`), 14-day retention. Stream name \`<runner_id>/<instance_id>\` so a stranded webhook pivots to logs in one query.
- Metric filter on \`JIT_NO_JOB_PICKUP\` -> \`JitRunners/RunnerAgent/SilentFailures\` (no alarm wired; manual query for now per spec).
- New \`lambda/internal/aws/ssm\` package with TTL cache + last-known-good fallback. Scaleup reads \`/jit-runners/runner-log-level\` on each invocation (30s cache); operators flip via \`aws ssm put-parameter\` to enable \`ACTIONS_RUNNER_DEBUG\`/\`ACTIONS_STEP_DEBUG\` without redeploying Lambda code.
- IAM additions to \`RunnerRole\` (logs:* on the new groups) and \`ScaleUpLambdaRole\` (ssm:GetParameter on the new parameter). Mirrored in CloudFormation + Terraform.
- Operator runbook in \`docs/troubleshooting.md\`.

Targets \`feat/gcp-support\` (PR #46) since this work depends on \`lambda/internal/aws/*\` layout from the cloud-agnostic refactor.

Spec: zettelkasten \`Projects/jit-runners/specs/2026-05-02-runner-agent-diagnostics-design.md\`.
Plan: zettelkasten \`Projects/jit-runners/plans/2026-05-02-runner-agent-diagnostics.md\`.

## Commits (10)

- \`fb4069b\` feat(ssm): Parameter Store loader with TTL cache
- \`9ce83fa\` feat(userdata): plumb runner_id, log level, silent-failure detection
- \`07bd843\` feat(scaleup): read runner-log-level from SSM and stamp runner_id
- \`8cdb7ee\` build(ami): install and configure CloudWatch agent
- \`c17680e\` infra(cfn): add diagnostic log groups, metric filter, SSM toggle
- \`ffd0707\` infra(tofu): mirror CFN diagnostic additions
- \`f79ad29\` docs: 'Debugging silent runner failures' subsection
- \`9efd714\` style: gofmt import order + handle ssmLoader.Get error explicitly

## Test plan

- [x] \`make check\` clean: golangci-lint 0 issues, go vet clean, 127 tests pass across 19 packages (118 baseline + 9 new SSM tests / userdata cases).
- [x] New SSM loader unit tests cover cache hit/miss, TTL refetch, missing-parameter fallback, API-error fallback, last-known-good preservation. Coverage: 100% of statements.
- [x] Userdata template tests pin RUNNER_ID export, conditional debug exports, threshold constant, tee redirect.
- [ ] After merge into \`feat/gcp-support\`: \`make ami.build\` produces an AMI containing the CloudWatch agent.
- [ ] CloudFormation update applies the new log groups + metric filter + SSM parameter; healthy CI run produces non-empty per-runner streams in \`/jit-runners/runner-agent\`.
- [ ] Synthetic silent-failure reproduction (revoke a JIT config before instance picks it up) produces exactly one \`JIT_NO_JOB_PICKUP\` event and increments the metric within 60s.
- [ ] SSM debug toggle: flip to \`debug\`, observe \`##[debug]\` markers in Worker_*.log, flip back to \`info\`.

## Out of scope (follow-ups)

- Alarm subscriber (Slack/PagerDuty) on \`SilentFailures\` — deferred per spec Q4.
- Stranded queued job sweep in scaledown — depends on the data this PR ships.
- Underlying matcher race that produced the original silent failure on runner 666 — separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)