### PR TITLE
fix(userdata): substitute ${RUNNER_ID} in CloudWatch agent config at runtime

### DIFF
--- a/lambda/internal/aws/ec2/userdata.go
+++ b/lambda/internal/aws/ec2/userdata.go
@@ -65,8 +65,11 @@ fi
 
 # Start the CloudWatch agent so runner-agent _diag/* logs and this script's
 # stdout (via tee) ship to CloudWatch even if run.sh exits within seconds.
-# RUNNER_ID is read by the baked config at /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json.
+# The agent's log_stream_name does NOT auto-expand shell env vars (only
+# its own placeholders like {instance_id}); substitute ${RUNNER_ID} into
+# the config file at runtime so the stream resolves to <runner_id>/<instance_id>.
 echo "=== jit-runners: starting CloudWatch agent ==="
+sed -i "s|\${RUNNER_ID}|${RUNNER_ID}|g" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 if ! systemctl start amazon-cloudwatch-agent; then
     echo "WARN: amazon-cloudwatch-agent failed to start; continuing without remote logs"
 fi

--- a/lambda/internal/aws/ec2/userdata_test.go
+++ b/lambda/internal/aws/ec2/userdata_test.go
@@ -27,6 +27,7 @@ func TestGenerateUserData(t *testing.T) {
 				"RUNNER_VERSION=\"2.321.0\"",
 				"JIT_CONFIG=\"encoded-jit-config-string\"",
 				"export RUNNER_ID=42",
+				"sed -i \"s|\\${RUNNER_ID}|${RUNNER_ID}|g\" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json",
 				"systemctl start amazon-cloudwatch-agent",
 				"./run.sh --jitconfig",
 				"tee /var/log/jit-runner-userdata.log",


### PR DESCRIPTION
## Summary

Caught during live verification of the v1.0.0-rc.3 deploy of issue #55 (PR #57).

The CloudWatch agent's \`log_stream_name\` field only expands its own placeholders (\`{instance_id}\`, \`{hostname}\`, etc.); **shell environment variables are NOT auto-expanded**. The spec's design assumed they would be — wrong assumption.

Result: all runners shared a single CloudWatch log stream named literally \`\${RUNNER_ID}/<instance_id>\` (the dollar-brace text was passed through as-is). Logs still flowed end-to-end, but the per-runner pivot from a webhook → logs query did not work as designed.

## Fix

Single-line addition to the userdata template — a \`sed\` pass before \`systemctl start amazon-cloudwatch-agent\` that substitutes the live \`RUNNER_ID\` into the baked agent config:

\`\`\`bash
sed -i \"s|\\\${RUNNER_ID}|\${RUNNER_ID}|g\" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
\`\`\`

No AMI rebuild required — the AMI ships the config with literal \`\${RUNNER_ID}\` placeholders (intentional via single-quoted heredoc); the substitution happens at boot.

## Test plan

- [x] Unit test \`TestGenerateUserData\` updated to assert the sed line is rendered. 127 tests pass.
- [ ] Post-merge: redeploy scaleup Lambda zip; new runners should produce streams with names \`<runner_id>/<instance_id>\` (no literal \`\${...}\` prefix).

Refs: devopsfactory-io/jit-runners#55, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)