### PR TITLE
fix(userdata): use systemctl restart for CloudWatch agent

### DIFF
--- a/lambda/internal/aws/ec2/userdata.go
+++ b/lambda/internal/aws/ec2/userdata.go
@@ -68,10 +68,13 @@ fi
 # The agent's log_stream_name does NOT auto-expand shell env vars (only
 # its own placeholders like {instance_id}); substitute ${RUNNER_ID} into
 # the config file at runtime so the stream resolves to <runner_id>/<instance_id>.
-echo "=== jit-runners: starting CloudWatch agent ==="
+# Use systemctl restart (not start) because the AMI's systemctl-enable
+# causes the agent to auto-start at boot BEFORE this userdata runs —
+# restart forces a config reload after the sed substitution.
+echo "=== jit-runners: restarting CloudWatch agent with substituted config ==="
 sed -i "s|\${RUNNER_ID}|${RUNNER_ID}|g" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-if ! systemctl start amazon-cloudwatch-agent; then
-    echo "WARN: amazon-cloudwatch-agent failed to start; continuing without remote logs"
+if ! systemctl restart amazon-cloudwatch-agent; then
+    echo "WARN: amazon-cloudwatch-agent failed to restart; continuing without remote logs"
 fi
 
 # Start the runner with JIT config (runs one job, then exits).

--- a/lambda/internal/aws/ec2/userdata_test.go
+++ b/lambda/internal/aws/ec2/userdata_test.go
@@ -28,7 +28,7 @@ func TestGenerateUserData(t *testing.T) {
 				"JIT_CONFIG=\"encoded-jit-config-string\"",
 				"export RUNNER_ID=42",
 				"sed -i \"s|\\${RUNNER_ID}|${RUNNER_ID}|g\" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json",
-				"systemctl start amazon-cloudwatch-agent",
+				"systemctl restart amazon-cloudwatch-agent",
 				"./run.sh --jitconfig",
 				"tee /var/log/jit-runner-userdata.log",
 				"RUNTIME_SECS",


### PR DESCRIPTION
## Summary

Follow-up to PR #58. The sed substitution from #58 was correct, but it ran TOO LATE: the AMI's \`08-cloudwatch-agent.sh\` does \`systemctl enable amazon-cloudwatch-agent\`, so systemd auto-starts the unit at boot BEFORE this userdata script runs. \`systemctl start\` on an already-running unit is a **no-op** — it does NOT reload config.

Result: the agent had already loaded the baked config with literal \`\${RUNNER_ID}\` placeholders. New streams kept appearing as \`\${RUNNER_ID}/i-...\`.

## Fix

Single-line change: \`systemctl start\` → \`systemctl restart\`. Restart forces a config reload after our sed substitution.

\`\`\`diff
-if ! systemctl start amazon-cloudwatch-agent; then
+if ! systemctl restart amazon-cloudwatch-agent; then
\`\`\`

No AMI rebuild required. Lambda redeploy only.

## Test plan

- [x] Existing test updated (\`systemctl start\` → \`systemctl restart\`). 127 tests pass.
- [ ] Post-merge: redeploy scaleup Lambda; new runners should produce streams named \`<runner_id>/<instance_id>\` (no literal \`\${...}\`).

## Why this is a separate PR from #58

PR #58 was based on the assumption that the agent had not yet started when userdata ran. The verification on PR #57 disproved that assumption — the AMI's \`systemctl enable\` causes early auto-start. Two-line follow-up rather than reopening #58.

Refs: devopsfactory-io/jit-runners#55, #57, #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)