### PR TITLE
fix(userdata): pass ACTIONS_*_DEBUG env vars through 'su - runner'

### DIFF
--- a/lambda/internal/aws/ec2/userdata.go
+++ b/lambda/internal/aws/ec2/userdata.go
@@ -81,7 +81,7 @@ fi
 echo "Starting runner with JIT config..."
 START_TIME=$(date +%s)
 set +e
-su - runner -c "cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'" 2>&1 | tee /var/log/jit-runner-userdata.log
+su - runner -c "export ACTIONS_RUNNER_DEBUG=${ACTIONS_RUNNER_DEBUG:-false} ACTIONS_STEP_DEBUG=${ACTIONS_STEP_DEBUG:-false}; cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'" 2>&1 | tee /var/log/jit-runner-userdata.log
 RUNNER_EXIT=${PIPESTATUS[0]}
 set -e
 END_TIME=$(date +%s)

--- a/lambda/internal/aws/ec2/userdata_test.go
+++ b/lambda/internal/aws/ec2/userdata_test.go
@@ -29,6 +29,7 @@ func TestGenerateUserData(t *testing.T) {
 				"export RUNNER_ID=42",
 				"sed -i \"s|\\${RUNNER_ID}|${RUNNER_ID}|g\" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json",
 				"systemctl restart amazon-cloudwatch-agent",
+				"su - runner -c \"export ACTIONS_RUNNER_DEBUG=",
 				"./run.sh --jitconfig",
 				"tee /var/log/jit-runner-userdata.log",
 				"RUNTIME_SECS",


### PR DESCRIPTION
## Summary

Third bug surfaced during live verification of issue #55 on PR #57.

\`su -\` (login shell) resets the environment, so when userdata exports \`ACTIONS_RUNNER_DEBUG=true\` and \`ACTIONS_STEP_DEBUG=true\` (driven by the SSM toggle from #56), those vars do **not** propagate to the runner agent process.

Verification on the live deploy:
- ✅ SSM toggle flipped to \`debug\`.
- ✅ Userdata rendered with \`export ACTIONS_RUNNER_DEBUG=true\` at script level.
- ❌ Runner agent's \`_diag/Runner_*.log\` only contained \`INFO\`-level lines, no \`DEBUG\`.
- ❌ No \`##[debug]\` markers in worker logs.

## Fix

Explicit env-var passthrough inside the \`su -c\` command:

\`\`\`diff
-su - runner -c "cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'"
+su - runner -c "export ACTIONS_RUNNER_DEBUG=${ACTIONS_RUNNER_DEBUG:-false} ACTIONS_STEP_DEBUG=${ACTIONS_STEP_DEBUG:-false}; cd /home/runner/actions-runner && ./run.sh --jitconfig '${JIT_CONFIG}'"
\`\`\`

Defaults to \`=false\` when unset so the rendered command stays valid in both info and debug modes. No AMI rebuild required; Lambda redeploy only.

## Test plan

- [x] Unit test pins the new \`su - runner -c "export ACTIONS_RUNNER_DEBUG=\` substring. 127 tests pass.
- [ ] Post-merge: redeploy scaleup; flip SSM to \`debug\`; trigger CI; observe \`DEBUG\`-level lines in runner-agent log group and/or \`##[debug]\` markers in Worker logs.

Refs: devopsfactory-io/jit-runners#55, #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)