### PR TITLE
feat(scaleup): demand-aware decision + rebalancer Lambda

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -49,6 +49,17 @@ builds:
     goarch:
       - amd64
 
+  - id: rebalancer
+    dir: lambda
+    main: ./cmd/rebalancer
+    binary: bootstrap
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+    goarch:
+      - amd64
+
 archives:
   - id: webhook-zip
     ids:
@@ -87,6 +98,16 @@ archives:
       - zip
     name_template: >-
       lifecycle-{{ .Os }}-{{ .Arch }}
+    strip_binary_directory: true
+    wrap_in_directory: false
+
+  - id: rebalancer-zip
+    ids:
+      - rebalancer
+    formats:
+      - zip
+    name_template: >-
+      rebalancer-{{ .Os }}-{{ .Arch }}
     strip_binary_directory: true
     wrap_in_directory: false
 

--- a/Makefile
+++ b/Makefile
@@ -15,17 +15,19 @@ lint: ## Run linters
 	cd lambda && golangci-lint run ./...
 
 lambda.build: ## Build Lambda binaries (named bootstrap for provided.al2023 runtime)
-	mkdir -p bin/webhook bin/scaleup bin/scaledown bin/lifecycle
+	mkdir -p bin/webhook bin/scaleup bin/scaledown bin/lifecycle bin/rebalancer
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/webhook/bootstrap ./cmd/webhook
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/scaleup/bootstrap ./cmd/scaleup
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/scaledown/bootstrap ./cmd/scaledown
 	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/lifecycle/bootstrap ./cmd/lifecycle
+	cd lambda && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o ../bin/rebalancer/bootstrap ./cmd/rebalancer
 
 lambda.zip: lambda.build ## Build Lambda zips (bootstrap at root for provided.al2023)
 	cd bin/webhook && zip -qj ../webhook.zip bootstrap
 	cd bin/scaleup && zip -qj ../scaleup.zip bootstrap
 	cd bin/scaledown && zip -qj ../scaledown.zip bootstrap
 	cd bin/lifecycle && zip -qj ../lifecycle.zip bootstrap
+	cd bin/rebalancer && zip -qj ../rebalancer.zip bootstrap
 
 lambda.test: ## Run Lambda tests with coverage
 	cd lambda && go test -coverprofile=coverage.out -covermode=atomic ./...

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -629,3 +629,55 @@ To exercise the silent-failure path on demand without a real workload:
 1. Generate a JIT config: `gh api -X POST repos/<owner>/<repo>/actions/runners/generate-jitconfig -f name=test -f labels[]=self-hosted -F runner_group_id=1`. Capture the `runner.id`.
 2. Immediately revoke it: `gh api -X DELETE repos/<owner>/<repo>/actions/runners/<runner.id>`.
 3. Send a synthetic SQS message to the scaleup queue carrying the revoked `encoded_jit_config`. A new spot instance launches, registers nothing, exits, and emits `JIT_NO_JOB_PICKUP`.
+
+## Stranded queued jobs
+
+A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely. Pre-issue #62, this happened because GitHub's matcher pairs runners with any queued matching job (often older stranded ones, not the specific job whose `queued` event triggered the runner's launch). The rebalancer Lambda closes this gap by periodically re-publishing `ScaleUpMessage`s for any queue depth not covered by pending runners.
+
+### Quick check: is the rebalancer healthy?
+
+```bash
+aws logs tail /aws/lambda/jit-runners-rebalancer --since 10m --filter-pattern '"cycle complete"' --format short
+```
+
+Expected: a `cycle complete demand=N supply=M published=K label_sets=L` line every minute. `published=K` should be 0 most of the time and non-zero only when there's actual drift to recover.
+
+### Find currently stranded jobs (operator triage)
+
+```bash
+gh api repos/devopsfactory-io/jit-runners/actions/runs?status=queued --jq '.workflow_runs[] | "\(.id)  \(.name)  \(.created_at)"'
+```
+
+For each queued run, list its queued jobs:
+
+```bash
+gh api repos/devopsfactory-io/jit-runners/actions/runs/<RUN_ID>/jobs --jq '.jobs[] | select(.status == "queued") | "  \(.id)  \(.name)  labels=\(.labels)"'
+```
+
+If the rebalancer is healthy and there are still stranded jobs older than ~5 minutes, escalate.
+
+### Verify scaleup is making demand-aware decisions
+
+```bash
+aws logs tail /aws/lambda/jit-runners-scaleup --since 10m --filter-pattern '"scaleup: skip"' --format short
+```
+
+A small number of skips per CI cycle is normal — they mean the webhook path correctly decided not to over-launch. A large number (every webhook skipping) suggests supply is already saturated; check whether legitimate demand is being met.
+
+### Manually fire a rebalance
+
+```bash
+aws lambda invoke --function-name jit-runners-rebalancer --invocation-type RequestResponse /tmp/rebalancer-out.json
+cat /tmp/rebalancer-out.json
+```
+
+Useful when investigating stranded jobs and you don't want to wait for the next 1-minute cycle.
+
+### Tuning the cadence
+
+If drift recovery feels too slow, the cadence can be tightened (subject to AWS::Events::Rule's `rate(1 minute)` minimum). Going below 1 minute requires `AWS::Scheduler::Schedule` (newer EventBridge Scheduler service); see issue #62 for the trade-off discussion.
+
+### References
+
+- Issue [#62](https://github.com/devopsfactory-io/jit-runners/issues/62) — diagnosis and design.
+- Spec: `repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md`.

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -6,6 +6,10 @@ Parameters:
     Type: String
     Description: GitHub App ID (numeric).
 
+  RepositoryFull:
+    Type: String
+    Description: GitHub repository in "owner/repo" form. Used by the rebalancer Lambda to query queued workflow_jobs.
+
   GitHubInstallationId:
     Type: String
     Description: GitHub App installation ID (numeric) used by lifecycle and scaledown for installation-token minting.
@@ -29,6 +33,10 @@ Parameters:
   LifecycleLambdaS3Key:
     Type: String
     Description: S3 key for the lifecycle Lambda zip.
+
+  RebalancerLambdaS3Key:
+    Type: String
+    Description: S3 key for the rebalancer Lambda zip (e.g. v1.0.0-rc.4/rebalancer.zip).
 
   WebhookSecretArn:
     Type: String
@@ -508,6 +516,39 @@ Resources:
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref PrivateKeySecretArn
 
+  RebalancerLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-rebalancer-lambda"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: RebalancerLambdaPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sqs:SendMessage
+                Resource: !GetAtt ScaleUpQueue.Arn
+              - Effect: Allow
+                Action:
+                  - dynamodb:Scan
+                Resource: !GetAtt RunnersTable.Arn
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref WebhookSecretArn
+                  - !Ref PrivateKeySecretArn
+
   LifecycleFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -536,6 +577,57 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-lifecycle"
       RetentionInDays: 14
+
+  RebalancerFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-rebalancer"
+      Description: Periodic re-publisher of ScaleUpMessages to drain stranded queued GitHub Actions jobs.
+      Runtime: provided.al2023
+      Handler: bootstrap
+      Architectures:
+        - x86_64
+      Timeout: 60
+      MemorySize: 256
+      ReservedConcurrentExecutions: 1
+      Role: !GetAtt RebalancerLambdaRole.Arn
+      Code:
+        S3Bucket: !Ref LambdaS3Bucket
+        S3Key: !Ref RebalancerLambdaS3Key
+      Environment:
+        Variables:
+          GITHUB_APP_ID: !Ref GitHubAppId
+          GITHUB_INSTALLATION_ID: !Ref GitHubInstallationId
+          GITHUB_APP_PRIVATE_KEY_SECRET_ARN: !Ref PrivateKeySecretArn
+          GITHUB_APP_WEBHOOK_SECRET_ARN: !Ref WebhookSecretArn
+          DYNAMODB_TABLE_NAME: !Ref RunnersTable
+          SQS_QUEUE_URL: !Ref ScaleUpQueue
+          REPOSITORY_FULL: !Ref RepositoryFull
+
+  RebalancerLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-rebalancer"
+      RetentionInDays: 14
+
+  RebalancerSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${AWS::StackName}-rebalancer-schedule"
+      Description: Fires the rebalancer Lambda every 1 minute to drain stranded queued jobs.
+      ScheduleExpression: rate(1 minute)
+      State: ENABLED
+      Targets:
+        - Id: RebalancerTarget
+          Arn: !GetAtt RebalancerFunction.Arn
+
+  RebalancerSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref RebalancerFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt RebalancerSchedule.Arn
 
   LifecycleFunctionEventSource:
     Type: AWS::Lambda::EventSourceMapping

--- a/infra/terraform/eventbridge.tf
+++ b/infra/terraform/eventbridge.tf
@@ -36,9 +36,12 @@ resource "aws_iam_role_policy" "scheduler" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect   = "Allow"
-      Action   = ["lambda:InvokeFunction"]
-      Resource = aws_lambda_function.scaledown.arn
+      Effect = "Allow"
+      Action = ["lambda:InvokeFunction"]
+      Resource = [
+        aws_lambda_function.scaledown.arn,
+        aws_lambda_function.rebalancer.arn,
+      ]
     }]
   })
 }

--- a/infra/terraform/rebalancer.tf
+++ b/infra/terraform/rebalancer.tf
@@ -1,0 +1,121 @@
+# Rebalancer Lambda (issue #62).
+#
+# Mirrors infra/cloudformation/template.yaml additions in the same change set.
+# Periodic scheduler that re-publishes ScaleUpMessages to drain stranded
+# queued GitHub Actions jobs.
+
+resource "aws_lambda_function" "rebalancer" {
+  function_name = "${var.project_name}-rebalancer"
+  description   = "Periodic re-publisher of ScaleUpMessages to drain stranded queued GitHub Actions jobs."
+  handler       = "bootstrap"
+  runtime       = "provided.al2023"
+  architectures = ["x86_64"]
+  memory_size   = 256
+  timeout       = 60
+
+  reserved_concurrent_executions = 1
+
+  s3_bucket = var.webhook_lambda_s3_bucket
+  s3_key    = var.rebalancer_lambda_s3_key
+
+  role = aws_iam_role.rebalancer_lambda.arn
+
+  environment {
+    variables = {
+      GITHUB_APP_ID                     = var.github_app_id
+      GITHUB_INSTALLATION_ID            = var.github_installation_id
+      GITHUB_APP_PRIVATE_KEY_SECRET_ARN = var.private_key_arn
+      GITHUB_APP_WEBHOOK_SECRET_ARN     = var.webhook_secret_arn
+      DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
+      SQS_QUEUE_URL                     = aws_sqs_queue.scaleup.url
+      REPOSITORY_FULL                   = var.repository_full
+    }
+  }
+
+  tags = {
+    Name = "${var.project_name}-rebalancer"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "rebalancer" {
+  name              = "/aws/lambda/${var.project_name}-rebalancer"
+  retention_in_days = 14
+}
+
+# --- IAM: Rebalancer Lambda ---
+
+resource "aws_iam_role" "rebalancer_lambda" {
+  name = "${var.project_name}-rebalancer-lambda"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "rebalancer_lambda_basic" {
+  role       = aws_iam_role.rebalancer_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "rebalancer_lambda" {
+  name = "${var.project_name}-rebalancer-lambda"
+  role = aws_iam_role.rebalancer_lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.rebalancer.arn}:*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = aws_sqs_queue.scaleup.arn
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:Scan"]
+        Resource = aws_dynamodb_table.runners.arn
+      },
+      {
+        Effect = "Allow"
+        Action = ["secretsmanager:GetSecretValue"]
+        Resource = [
+          var.webhook_secret_arn,
+          var.private_key_arn,
+        ]
+      },
+    ]
+  })
+}
+
+# --- EventBridge Scheduler: Rebalancer ---
+
+resource "aws_scheduler_schedule" "rebalancer" {
+  name       = "${var.project_name}-rebalancer"
+  group_name = "default"
+
+  flexible_time_window {
+    mode = "OFF"
+  }
+
+  schedule_expression = "rate(1 minute)"
+
+  target {
+    arn      = aws_lambda_function.rebalancer.arn
+    role_arn = aws_iam_role.scheduler.arn
+  }
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -90,6 +90,16 @@ variable "lifecycle_lambda_s3_key" {
   type        = string
 }
 
+variable "rebalancer_lambda_s3_key" {
+  type        = string
+  description = "S3 key for the rebalancer Lambda zip (e.g. v1.0.0-rc.4/rebalancer.zip)."
+}
+
+variable "repository_full" {
+  type        = string
+  description = "GitHub repository in owner/repo form. Used by the rebalancer Lambda to query queued workflow_jobs."
+}
+
 # --- Scale-down ---
 
 variable "stale_threshold_minutes" {

--- a/lambda/cmd/rebalancer/main.go
+++ b/lambda/cmd/rebalancer/main.go
@@ -1,0 +1,100 @@
+// Package main is the rebalancer Lambda entry point.
+//
+// EventBridge fires this Lambda every 1 minute. The handler instantiates
+// the GitHub client, DDB store, and SQS publisher; computes the
+// per-label-set (demand - supply) gap; and publishes ScaleUpMessage with
+// Source=SourceRebalancer for each missing slot. See the design spec at
+// repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	awssqssdk "github.com/aws/aws-sdk-go-v2/service/sqs"
+
+	awsdynamo "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/dynamo"
+	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
+	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/rebalancer"
+)
+
+var (
+	cfgOnce sync.Once
+	appCfg  *appconfig.Config
+	cfgErr  error
+)
+
+func main() {
+	lambda.Start(handler)
+}
+
+// handler is invoked by EventBridge with no payload. We ignore the payload
+// and run a single rebalance cycle. Errors are logged but the handler
+// returns nil so EventBridge does not retry-storm; the next 1-minute cycle
+// re-attempts with a fresh rate budget.
+func handler(ctx context.Context) error {
+	cfg, err := loadConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	if cfg.RepositoryFull == "" {
+		return fmt.Errorf("rebalancer: REPOSITORY_FULL env var is required")
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("load AWS config: %w", err)
+	}
+
+	store := awsdynamo.NewStore(dynamodb.NewFromConfig(awsCfg), cfg.TableName)
+	publisher := awssqs.NewPublisher(awssqssdk.NewFromConfig(awsCfg), cfg.QueueURL)
+
+	ghClient, err := newGitHubClient(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("github client: %w", err)
+	}
+
+	if err := rebalancer.Rebalance(ctx, ghClient, store, publisher, cfg.RepositoryFull, cfg.InstallationID); err != nil {
+		log.Printf("rebalancer: cycle error: %v", err)
+		// Return nil so EventBridge does not retry-storm. Next cycle (1 min)
+		// re-attempts with a fresh rate budget.
+		return nil
+	}
+	return nil
+}
+
+// newGitHubClient mints a fresh installation token and returns a real
+// *github.Client. Mirrors the pattern in cmd/scaledown/main.go.
+func newGitHubClient(ctx context.Context, cfg *appconfig.Config) (*github.Client, error) {
+	if cfg.InstallationID == 0 {
+		return nil, fmt.Errorf("rebalancer: GITHUB_INSTALLATION_ID is required")
+	}
+	token, err := github.InstallationToken(ctx, cfg.AppID, cfg.PrivateKey, cfg.InstallationID)
+	if err != nil {
+		return nil, fmt.Errorf("mint installation token: %w", err)
+	}
+	return github.NewClient(token), nil
+}
+
+func loadConfig(ctx context.Context) (*appconfig.Config, error) {
+	cfgOnce.Do(func() {
+		appCfg, cfgErr = appconfig.Load(ctx)
+	})
+	return appCfg, cfgErr
+}
+
+func init() {
+	log.SetFlags(log.Lshortfile)
+	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
+		log.SetOutput(os.Stdout)
+	}
+}

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -31,6 +31,12 @@ import (
 
 const defaultRunnerVersion = "2.332.0"
 
+// queueLister abstracts the listing call for testability. Production code
+// passes *github.Client which satisfies this interface.
+type queueLister interface {
+	ListQueuedWorkflowJobs(ctx context.Context, ownerRepo string) ([]github.QueuedJob, error)
+}
+
 var (
 	cfgOnce sync.Once
 	appCfg  *appconfig.Config
@@ -97,6 +103,17 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, launcher compute.
 	// name is purely cosmetic per GitHub's JIT contract — we use a UUID so
 	// no future reader assumes a binding to job_id or workflow_run_id.
 	ghClient := github.NewClient(token)
+
+	launch, err := shouldLaunch(ctx, ghClient, store, msg)
+	if err != nil {
+		return fmt.Errorf("scaleup decision: %w", err)
+	}
+	if !launch {
+		log.Printf("scaleup: skip %s job=%d labels=%v: demand <= supply (Source=%q)",
+			msg.RepositoryFull, msg.JobID, msg.Labels, msg.Source)
+		return nil
+	}
+
 	runnerName := "jit-" + uuid.NewString()
 	customLabels := webhook.CustomLabels(msg.Labels)
 	jitCfg, err := ghClient.GenerateJITConfig(ctx, msg.RepositoryFull, runnerName, msg.Labels)
@@ -238,6 +255,46 @@ func resolveAMI(cfg *appconfig.Config, labels []string) string {
 		}
 	}
 	return cfg.DefaultAMI
+}
+
+// shouldLaunch decides whether to proceed with the launch pipeline for a
+// given ScaleUpMessage. Returns true if the message's Source warrants an
+// unconditional launch (rebalancer) or if the webhook-path demand check
+// passes (queued matching jobs > pending matching runners).
+//
+// "Matching" uses subset semantics: a pending runner whose labels are a
+// superset of the queued job's labels is considered supply.
+//
+// On the webhook path, an empty Source is treated as SourceWebhook for
+// backwards compat with in-flight messages at deploy time.
+func shouldLaunch(ctx context.Context, gh queueLister, store state.RunnerStore, msg *awssqs.ScaleUpMessage) (bool, error) {
+	if msg.Source == awssqs.SourceRebalancer {
+		return true, nil
+	}
+
+	queued, err := gh.ListQueuedWorkflowJobs(ctx, msg.RepositoryFull)
+	if err != nil {
+		return false, fmt.Errorf("scaleup: list queued jobs: %w", err)
+	}
+	demand := 0
+	for _, j := range queued {
+		if state.MatchesLabels(msg.Labels, j.Labels) {
+			demand++
+		}
+	}
+
+	pending, err := store.List(ctx, state.Filter{StatusEq: state.StatusPending})
+	if err != nil {
+		return false, fmt.Errorf("scaleup: list pending runners: %w", err)
+	}
+	supply := 0
+	for _, r := range pending {
+		if state.MatchesLabels(r.Labels, msg.Labels) {
+			supply++
+		}
+	}
+
+	return demand > supply, nil
 }
 
 func loadConfig(ctx context.Context) (*appconfig.Config, error) {

--- a/lambda/cmd/scaleup/main_integration_test.go
+++ b/lambda/cmd/scaleup/main_integration_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/google/uuid"
 
+	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	appconfig "github.com/devopsfactory-io/jit-runners/lambda/internal/config"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/runner"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
@@ -99,5 +101,122 @@ func TestPendingRecordKeyedByGitHubRunnerID(t *testing.T) {
 
 	if _, err := store.Get(ctx, "owner/repo#4567"); !errors.Is(err, state.ErrNotFound) {
 		t.Errorf("legacy key 'owner/repo#4567' must be unreachable; got err=%v", err)
+	}
+}
+
+type fakeQueueLister struct {
+	jobs []github.QueuedJob
+	err  error
+}
+
+func (f *fakeQueueLister) ListQueuedWorkflowJobs(_ context.Context, _ string) ([]github.QueuedJob, error) {
+	return f.jobs, f.err
+}
+
+func TestShouldLaunch(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    string
+		queued    []github.QueuedJob
+		pending   []state.Runner
+		msgLabels []string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name:      "rebalancer source always launches",
+			source:    awssqs.SourceRebalancer,
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      true,
+		},
+		{
+			name:   "webhook source: demand > supply launches",
+			source: awssqs.SourceWebhook,
+			queued: []github.QueuedJob{
+				{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}},
+				{JobID: 2, Status: "queued", Labels: []string{"self-hosted", "large"}},
+			},
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      true,
+		},
+		{
+			name:      "webhook source: demand == supply skips",
+			source:    awssqs.SourceWebhook,
+			queued:    []github.QueuedJob{{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}}},
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      false,
+		},
+		{
+			name:   "webhook source: demand < supply skips",
+			source: awssqs.SourceWebhook,
+			queued: []github.QueuedJob{{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}}},
+			pending: []state.Runner{
+				{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}},
+				{ID: "2", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}},
+			},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      false,
+		},
+		{
+			name:      "empty Source treated as webhook",
+			source:    "",
+			queued:    []github.QueuedJob{{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}}},
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      false,
+		},
+		{
+			name:      "subset match: runner with extra label counts as supply",
+			source:    awssqs.SourceWebhook,
+			queued:    []github.QueuedJob{{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}}},
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "large", "x64"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      false,
+		},
+		{
+			name:      "different label set: pending runner with diff labels does NOT count as supply",
+			source:    awssqs.SourceWebhook,
+			queued:    []github.QueuedJob{{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}}},
+			pending:   []state.Runner{{ID: "1", Status: state.StatusPending, Labels: []string{"self-hosted", "medium"}}},
+			msgLabels: []string{"self-hosted", "large"},
+			want:      true,
+		},
+		{
+			name:      "GH error returned",
+			source:    awssqs.SourceWebhook,
+			msgLabels: []string{"self-hosted", "large"},
+			wantErr:   true,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			gh := &fakeQueueLister{jobs: tc.queued}
+			if tc.wantErr {
+				gh.err = errors.New("synthetic")
+			}
+			store := memstore.New()
+			ctx := context.Background()
+			for _, r := range tc.pending {
+				if err := store.Put(ctx, r); err != nil {
+					t.Fatalf("Put: %v", err)
+				}
+			}
+			msg := &awssqs.ScaleUpMessage{
+				Source:         tc.source,
+				Labels:         tc.msgLabels,
+				RepositoryFull: "owner/repo",
+			}
+			got, err := shouldLaunch(ctx, gh, store, msg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("shouldLaunch = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/lambda/internal/aws/sqs/types.go
+++ b/lambda/internal/aws/sqs/types.go
@@ -1,6 +1,22 @@
 package sqs
 
-// ScaleUpMessage is the SQS message sent from the webhook Lambda to the scale-up Lambda.
+// Source values for ScaleUpMessage. Empty string is treated as SourceWebhook
+// for backwards compat with in-flight messages at deploy time.
+const (
+	SourceWebhook    = "webhook"
+	SourceRebalancer = "rebalancer"
+)
+
+// ScaleUpMessage is the SQS message sent from the webhook Lambda or the
+// rebalancer Lambda to the scale-up Lambda. Source disambiguates the
+// trigger so scaleup can apply the correct demand-aware decision policy:
+//
+//   - SourceWebhook (default for empty Source): scaleup launches AT MOST 1
+//     runner per message, only when GitHub queue depth exceeds the count of
+//     DDB pending runners matching msg.Labels.
+//   - SourceRebalancer: scaleup launches 1 runner unconditionally per
+//     message — the rebalancer pre-counted the gap and publishes one
+//     message per missing slot.
 type ScaleUpMessage struct {
 	EventAction    string   `json:"event_action"`
 	JobID          int64    `json:"job_id"`
@@ -8,6 +24,10 @@ type ScaleUpMessage struct {
 	RepositoryFull string   `json:"repository_full"`
 	Labels         []string `json:"labels"`
 	InstallationID int64    `json:"installation_id"`
+
+	// Source identifies which Lambda published this message. See the
+	// constants above. Empty Source is treated as SourceWebhook.
+	Source string `json:"source,omitempty"`
 
 	// ReEnqueueAttempts is incremented by scaledown each time a stuck pending
 	// runner triggers a re-enqueue. Scaleup uses it as a budget check (skip

--- a/lambda/internal/config/config.go
+++ b/lambda/internal/config/config.go
@@ -34,6 +34,12 @@ type Config struct {
 	// the installation from the SQS message payload directly.
 	InstallationID int64
 
+	// RepositoryFull is the GitHub repository in "owner/repo" form.
+	// Used by the rebalancer Lambda to query queued workflow_jobs.
+	// Required when the rebalancer Lambda is deployed (set via the
+	// REPOSITORY_FULL env var).
+	RepositoryFull string
+
 	// SQS queue URL for scale-up messages.
 	QueueURL string
 
@@ -84,6 +90,7 @@ func LoadWith(ctx context.Context, loader secrets.Loader) (*Config, error) {
 		SecurityGroupID:    os.Getenv("EC2_SECURITY_GROUP_ID"),
 		IAMInstanceProfile: os.Getenv("EC2_IAM_INSTANCE_PROFILE"),
 		DefaultAMI:         os.Getenv("EC2_DEFAULT_AMI"),
+		RepositoryFull:     os.Getenv("REPOSITORY_FULL"),
 	}
 
 	if err := validateRequiredEnv(cfg); err != nil {

--- a/lambda/internal/config/config_test.go
+++ b/lambda/internal/config/config_test.go
@@ -73,6 +73,7 @@ func TestLoad_Success(t *testing.T) {
 	t.Setenv("GITHUB_APP_PRIVATE_KEY", "my-private-key")
 	t.Setenv("EC2_SUBNET_IDS", "subnet-1,subnet-2")
 	t.Setenv("LABEL_MAPPINGS", `[{"label":"gpu","instance_type":"g4dn.xlarge"}]`)
+	t.Setenv("REPOSITORY_FULL", "owner/repo")
 
 	cfg, err := Load(context.Background())
 	if err != nil {
@@ -96,6 +97,9 @@ func TestLoad_Success(t *testing.T) {
 	}
 	if cfg.InstallationID != 0 {
 		t.Errorf("InstallationID = %d, want 0 (unset)", cfg.InstallationID)
+	}
+	if cfg.RepositoryFull != "owner/repo" {
+		t.Errorf("RepositoryFull = %q, want %q", cfg.RepositoryFull, "owner/repo")
 	}
 }
 
@@ -168,6 +172,7 @@ func clearEnv(t *testing.T) {
 		"GITHUB_INSTALLATION_ID",
 		"EC2_SUBNET_IDS", "EC2_SECURITY_GROUP_ID", "EC2_IAM_INSTANCE_PROFILE",
 		"EC2_DEFAULT_AMI", "LABEL_MAPPINGS",
+		"REPOSITORY_FULL",
 	}
 	for _, k := range envVars {
 		t.Setenv(k, "")

--- a/lambda/internal/github/client.go
+++ b/lambda/internal/github/client.go
@@ -111,6 +111,26 @@ type JITRunner struct {
 	Name string `json:"name"`
 }
 
+// QueuedJob is a workflow_job in queued state, returned by
+// ListQueuedWorkflowJobs. Used by the rebalancer Lambda to compute demand
+// and by cmd/scaleup for the demand-aware decision.
+type QueuedJob struct {
+	JobID  int64    `json:"id"`
+	RunID  int64    `json:"run_id"`
+	Status string   `json:"status"`
+	Labels []string `json:"labels"`
+}
+
+type listRunsResponse struct {
+	WorkflowRuns []struct {
+		ID int64 `json:"id"`
+	} `json:"workflow_runs"`
+}
+
+type listJobsResponse struct {
+	Jobs []QueuedJob `json:"jobs"`
+}
+
 // GenerateJITConfig requests a just-in-time runner configuration from GitHub.
 // This creates a single-use runner that auto-deregisters after one job.
 func (c *Client) GenerateJITConfig(ctx context.Context, ownerRepo string, name string, labels []string) (*JITRunnerConfig, error) {
@@ -185,4 +205,80 @@ func (c *Client) DeregisterRunner(ctx context.Context, ownerRepo string, runnerI
 		return nil
 	}
 	return fmt.Errorf("github: DeregisterRunner %d: status %d", runnerID, resp.StatusCode)
+}
+
+// ListQueuedWorkflowJobs returns all workflow_jobs currently in `queued`
+// status across the repo. Implementation: list workflow runs filtered to
+// status=queued, then per-run list jobs and filter to status=queued.
+// Pagination is requested at per_page=100 (workflows seldom exceed 100
+// queued jobs at once; if needed, callers iterate via the periodic
+// rebalancer cycle which re-queries each minute).
+func (c *Client) ListQueuedWorkflowJobs(ctx context.Context, ownerRepo string) ([]QueuedJob, error) {
+	runs, err := c.listQueuedRuns(ctx, ownerRepo)
+	if err != nil {
+		return nil, err
+	}
+	var queued []QueuedJob
+	for _, run := range runs {
+		jobs, err := c.listJobsForRun(ctx, ownerRepo, run.ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, j := range jobs {
+			if j.Status == "queued" {
+				queued = append(queued, j)
+			}
+		}
+	}
+	return queued, nil
+}
+
+func (c *Client) listQueuedRuns(ctx context.Context, ownerRepo string) ([]struct {
+	ID int64 `json:"id"`
+}, error) {
+	url := fmt.Sprintf("%s/repos/%s/actions/runs?status=queued&per_page=100", c.baseURL, ownerRepo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704
+	if err != nil {
+		return nil, fmt.Errorf("github: list queued runs: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: list queued runs: status %d", resp.StatusCode)
+	}
+	var body listRunsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("github: list queued runs decode: %w", err)
+	}
+	return body.WorkflowRuns, nil
+}
+
+func (c *Client) listJobsForRun(ctx context.Context, ownerRepo string, runID int64) ([]QueuedJob, error) {
+	url := fmt.Sprintf("%s/repos/%s/actions/runs/%d/jobs?per_page=100", c.baseURL, ownerRepo, runID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	resp, err := c.httpClient.Do(req) //nolint:gosec // G704
+	if err != nil {
+		return nil, fmt.Errorf("github: list jobs for run %d: %w", runID, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github: list jobs for run %d: status %d", runID, resp.StatusCode)
+	}
+	var body listJobsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("github: list jobs for run %d decode: %w", runID, err)
+	}
+	return body.Jobs, nil
 }

--- a/lambda/internal/github/client_test.go
+++ b/lambda/internal/github/client_test.go
@@ -89,3 +89,93 @@ func TestClient_DeregisterRunner_NegativeID(t *testing.T) {
 		t.Fatal("negative ID should not hit the network")
 	}
 }
+
+func TestListQueuedWorkflowJobs(t *testing.T) {
+	t.Run("empty repo returns empty slice", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/repos/owner/repo/actions/runs" {
+				_, _ = w.Write([]byte(`{"total_count":0,"workflow_runs":[]}`))
+				return
+			}
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}))
+		defer srv.Close()
+
+		c := NewClientWithBase("test-token", srv.URL)
+		got, err := c.ListQueuedWorkflowJobs(context.Background(), "owner/repo")
+		if err != nil {
+			t.Fatalf("ListQueuedWorkflowJobs: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d jobs, want 0", len(got))
+		}
+	})
+
+	t.Run("single queued run with two queued jobs", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/repos/owner/repo/actions/runs":
+				_, _ = w.Write([]byte(`{"total_count":1,"workflow_runs":[{"id":111}]}`))
+			case "/repos/owner/repo/actions/runs/111/jobs":
+				_, _ = w.Write([]byte(`{"total_count":2,"jobs":[
+				 {"id":1001,"run_id":111,"status":"queued","labels":["self-hosted","large"]},
+				 {"id":1002,"run_id":111,"status":"queued","labels":["self-hosted","medium"]}
+				]}`))
+			default:
+				t.Fatalf("unexpected path: %s", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClientWithBase("test-token", srv.URL)
+		got, err := c.ListQueuedWorkflowJobs(context.Background(), "owner/repo")
+		if err != nil {
+			t.Fatalf("ListQueuedWorkflowJobs: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d jobs, want 2", len(got))
+		}
+		if got[0].JobID != 1001 || got[1].JobID != 1002 {
+			t.Errorf("unexpected job IDs: %+v", got)
+		}
+	})
+
+	t.Run("filters out non-queued jobs in same run", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/repos/owner/repo/actions/runs":
+				_, _ = w.Write([]byte(`{"total_count":1,"workflow_runs":[{"id":111}]}`))
+			case "/repos/owner/repo/actions/runs/111/jobs":
+				_, _ = w.Write([]byte(`{"total_count":2,"jobs":[
+				 {"id":1001,"run_id":111,"status":"queued","labels":["self-hosted","large"]},
+				 {"id":1002,"run_id":111,"status":"in_progress","labels":["self-hosted","large"]}
+				]}`))
+			default:
+				t.Fatalf("unexpected path: %s", r.URL.Path)
+			}
+		}))
+		defer srv.Close()
+
+		c := NewClientWithBase("test-token", srv.URL)
+		got, err := c.ListQueuedWorkflowJobs(context.Background(), "owner/repo")
+		if err != nil {
+			t.Fatalf("ListQueuedWorkflowJobs: %v", err)
+		}
+		if len(got) != 1 || got[0].JobID != 1001 {
+			t.Errorf("expected only job 1001, got %+v", got)
+		}
+	})
+
+	t.Run("server error returns wrapped error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}))
+		defer srv.Close()
+
+		c := NewClientWithBase("test-token", srv.URL)
+		_, err := c.ListQueuedWorkflowJobs(context.Background(), "owner/repo")
+		if err == nil {
+			t.Fatal("expected error on 429, got nil")
+		}
+	})
+}

--- a/lambda/internal/rebalancer/rebalancer.go
+++ b/lambda/internal/rebalancer/rebalancer.go
@@ -1,0 +1,142 @@
+// Package rebalancer holds the periodic-scheduler logic that closes the
+// stranded-queued-jobs drift cycle. See spec at
+// repositories/zettelkasten/Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md.
+package rebalancer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+
+	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+)
+
+// QueueLister is the narrow GitHub surface the rebalancer needs.
+// Satisfied by *github.Client.
+type QueueLister interface {
+	ListQueuedWorkflowJobs(ctx context.Context, ownerRepo string) ([]github.QueuedJob, error)
+}
+
+// ScaleUpPublisher is the narrow SQS publisher surface. Satisfied by
+// *aws/sqs.Publisher via its PublishScaleUp helper.
+type ScaleUpPublisher interface {
+	PublishScaleUp(ctx context.Context, msg *awssqs.ScaleUpMessage) error
+}
+
+// Rebalance computes per-label-set demand from GitHub and supply from DDB
+// pending runners, and publishes (demand - supply) ScaleUpMessages with
+// Source=SourceRebalancer for each gap. The published messages flow through
+// the same scaleup launch pipeline as webhook-fired ones, but scaleup
+// launches them unconditionally because Source=SourceRebalancer.
+//
+// Errors during GH listing or DDB scan are returned without publishing.
+// Errors during a publish are aggregated; partial-success publishes remain
+// in flight (the next cycle re-fires whatever wasn't delivered, since the
+// queued jobs still appear in GH).
+func Rebalance(ctx context.Context, gh QueueLister, store state.RunnerStore, pub ScaleUpPublisher, repoFull string, installationID int64) error {
+	queued, err := gh.ListQueuedWorkflowJobs(ctx, repoFull)
+	if err != nil {
+		return fmt.Errorf("rebalancer: list queued jobs: %w", err)
+	}
+
+	pending, err := store.List(ctx, state.Filter{StatusEq: state.StatusPending})
+	if err != nil {
+		return fmt.Errorf("rebalancer: list pending runners: %w", err)
+	}
+
+	groups := groupByLabels(queued)
+	var publishErrs []error
+	totalPublished := 0
+	for _, g := range groups {
+		supply := 0
+		for _, r := range pending {
+			if state.MatchesLabels(r.Labels, g.labels) {
+				supply++
+			}
+		}
+		gap := len(g.jobs) - supply
+		if gap <= 0 {
+			continue
+		}
+		anchor := g.jobs[0]
+		for i := 0; i < gap; i++ {
+			msg := &awssqs.ScaleUpMessage{
+				EventAction:    "queued",
+				JobID:          anchor.JobID,
+				RunID:          anchor.RunID,
+				RepositoryFull: repoFull,
+				Labels:         g.labels,
+				InstallationID: installationID,
+				Source:         awssqs.SourceRebalancer,
+			}
+			if err := pub.PublishScaleUp(ctx, msg); err != nil {
+				publishErrs = append(publishErrs, fmt.Errorf("publish for labels %v: %w", g.labels, err))
+				continue
+			}
+			totalPublished++
+		}
+	}
+	log.Printf("rebalancer: cycle complete demand=%d supply=%d published=%d label_sets=%d",
+		len(queued), len(pending), totalPublished, len(groups))
+	if len(publishErrs) > 0 {
+		return errors.Join(publishErrs...)
+	}
+	return nil
+}
+
+type labelGroup struct {
+	labels []string
+	jobs   []github.QueuedJob
+}
+
+// groupByLabels groups queued jobs by their normalized label set. Jobs whose
+// labels are equal-as-sets (case- and order-insensitive) go in the same
+// group. Order of jobs within a group is preserved (so jobs[0] is the
+// earliest the GH API returned, useful as the anchor job_id for the
+// published message).
+func groupByLabels(jobs []github.QueuedJob) []*labelGroup {
+	idx := map[string]*labelGroup{}
+	var order []*labelGroup
+	for _, j := range jobs {
+		k := labelKey(j.Labels)
+		g, ok := idx[k]
+		if !ok {
+			g = &labelGroup{labels: j.Labels}
+			idx[k] = g
+			order = append(order, g)
+		}
+		g.jobs = append(g.jobs, j)
+	}
+	return order
+}
+
+// labelKey returns a stable string key for a label set: lowercase, sorted,
+// nul-separated. Used purely for grouping equal label sets together.
+func labelKey(labels []string) string {
+	s := make([]string, len(labels))
+	for i, l := range labels {
+		s[i] = lower(l)
+	}
+	sort.Strings(s)
+	key := ""
+	for _, x := range s {
+		key += "\x00" + x
+	}
+	return key
+}
+
+func lower(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
+}

--- a/lambda/internal/rebalancer/rebalancer_test.go
+++ b/lambda/internal/rebalancer/rebalancer_test.go
@@ -1,0 +1,165 @@
+package rebalancer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	awssqs "github.com/devopsfactory-io/jit-runners/lambda/internal/aws/sqs"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/github"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
+)
+
+type fakeGH struct {
+	jobs []github.QueuedJob
+	err  error
+}
+
+func (f *fakeGH) ListQueuedWorkflowJobs(_ context.Context, _ string) ([]github.QueuedJob, error) {
+	return f.jobs, f.err
+}
+
+type fakePub struct {
+	published []*awssqs.ScaleUpMessage
+	err       error
+}
+
+func (f *fakePub) PublishScaleUp(_ context.Context, m *awssqs.ScaleUpMessage) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.published = append(f.published, m)
+	return nil
+}
+
+func TestRebalance_NoQueuedNoPublishes(t *testing.T) {
+	gh := &fakeGH{jobs: nil}
+	store := memstore.New()
+	pub := &fakePub{}
+
+	if err := Rebalance(context.Background(), gh, store, pub, "owner/repo", 42); err != nil {
+		t.Fatalf("Rebalance: %v", err)
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("expected 0 publishes, got %d", len(pub.published))
+	}
+}
+
+func TestRebalance_DemandExceedsSupply_PublishesGap(t *testing.T) {
+	gh := &fakeGH{jobs: []github.QueuedJob{
+		{JobID: 1, RunID: 100, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 2, RunID: 100, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 3, RunID: 200, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 4, RunID: 200, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 5, RunID: 200, Status: "queued", Labels: []string{"self-hosted", "large"}},
+	}}
+	store := memstore.New()
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if err := store.Put(ctx, state.Runner{
+			ID:     fmt.Sprintf("r%d", i),
+			Status: state.StatusPending,
+			Labels: []string{"self-hosted", "large"},
+		}); err != nil {
+			t.Fatalf("Put: %v", err)
+		}
+	}
+	pub := &fakePub{}
+
+	if err := Rebalance(ctx, gh, store, pub, "owner/repo", 42); err != nil {
+		t.Fatalf("Rebalance: %v", err)
+	}
+	if len(pub.published) != 3 {
+		t.Errorf("expected 3 publishes (5 demand - 2 supply), got %d", len(pub.published))
+	}
+	for _, m := range pub.published {
+		if m.Source != awssqs.SourceRebalancer {
+			t.Errorf("published Source = %q, want %q", m.Source, awssqs.SourceRebalancer)
+		}
+		if m.RepositoryFull != "owner/repo" {
+			t.Errorf("published RepositoryFull = %q, want %q", m.RepositoryFull, "owner/repo")
+		}
+		if m.InstallationID != 42 {
+			t.Errorf("published InstallationID = %d, want 42", m.InstallationID)
+		}
+	}
+}
+
+func TestRebalance_TwoLabelSetsIndependent(t *testing.T) {
+	gh := &fakeGH{jobs: []github.QueuedJob{
+		{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 2, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 3, Status: "queued", Labels: []string{"self-hosted", "large"}},
+		{JobID: 4, Status: "queued", Labels: []string{"self-hosted", "medium"}},
+		{JobID: 5, Status: "queued", Labels: []string{"self-hosted", "medium"}},
+	}}
+	store := memstore.New()
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		_ = store.Put(ctx, state.Runner{
+			ID:     fmt.Sprintf("r%d", i),
+			Status: state.StatusPending,
+			Labels: []string{"self-hosted", "large"},
+		})
+	}
+	pub := &fakePub{}
+
+	if err := Rebalance(ctx, gh, store, pub, "owner/repo", 42); err != nil {
+		t.Fatalf("Rebalance: %v", err)
+	}
+	if len(pub.published) != 3 {
+		t.Errorf("expected 3 publishes (1 large + 2 medium), got %d", len(pub.published))
+	}
+	largeCount, mediumCount := 0, 0
+	for _, m := range pub.published {
+		if state.MatchesLabels(m.Labels, []string{"self-hosted", "large"}) {
+			largeCount++
+		}
+		if state.MatchesLabels(m.Labels, []string{"self-hosted", "medium"}) {
+			mediumCount++
+		}
+	}
+	if largeCount != 1 {
+		t.Errorf("large publishes = %d, want 1", largeCount)
+	}
+	if mediumCount != 2 {
+		t.Errorf("medium publishes = %d, want 2", mediumCount)
+	}
+}
+
+func TestRebalance_SubsetMatchCountsAsSupply(t *testing.T) {
+	gh := &fakeGH{jobs: []github.QueuedJob{
+		{JobID: 1, Status: "queued", Labels: []string{"self-hosted", "large"}},
+	}}
+	store := memstore.New()
+	ctx := context.Background()
+	_ = store.Put(ctx, state.Runner{
+		ID:     "r1",
+		Status: state.StatusPending,
+		Labels: []string{"self-hosted", "large", "x64"},
+	})
+	pub := &fakePub{}
+
+	if err := Rebalance(ctx, gh, store, pub, "owner/repo", 42); err != nil {
+		t.Fatalf("Rebalance: %v", err)
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("expected 0 publishes (subset match counts as supply), got %d", len(pub.published))
+	}
+}
+
+func TestRebalance_GHErrorPropagates(t *testing.T) {
+	gh := &fakeGH{err: errors.New("rate-limited")}
+	store := memstore.New()
+	pub := &fakePub{}
+
+	err := Rebalance(context.Background(), gh, store, pub, "owner/repo", 42)
+	if err == nil {
+		t.Fatal("expected error on GH failure")
+	}
+	if len(pub.published) != 0 {
+		t.Errorf("expected 0 publishes on error, got %d", len(pub.published))
+	}
+}

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -148,6 +148,7 @@ func (c *Cleaner) sweepStalePending(ctx context.Context, runners []state.Runner,
 				JobID:             r.JobID,
 				RepositoryFull:    r.Repository,
 				Labels:            r.Labels,
+				Source:            awssqs.SourceWebhook,
 				ReEnqueueAttempts: next,
 			}
 			if err := c.ScaleUpPublisher.PublishScaleUp(ctx, msg); err != nil {

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -202,6 +202,9 @@ func TestCleaner_StalePending_UnderBudget(t *testing.T) {
 	if pub.msgs[0].JobID != 1 || pub.msgs[0].RepositoryFull != rec.Repository {
 		t.Errorf("republished message body mismatch: %+v", pub.msgs[0])
 	}
+	if pub.msgs[0].Source != awssqs.SourceWebhook {
+		t.Errorf("re-enqueue Source = %q, want %q", pub.msgs[0].Source, awssqs.SourceWebhook)
+	}
 	if len(store.updates) != 1 {
 		t.Fatalf("expected 1 store update, got %d", len(store.updates))
 	}

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -67,3 +67,35 @@ type RunnerStore interface {
 	Update(ctx context.Context, id string, fields RunnerUpdate) error
 	Delete(ctx context.Context, id string) error
 }
+
+// MatchesLabels reports whether a runner with `runnerLabels` can satisfy a
+// job with `jobLabels`. GitHub's matcher uses subset semantics: a runner
+// matches a job iff every job label is present in the runner's label set.
+// The compare is case-insensitive and order-insensitive.
+//
+// Used by both cmd/scaleup (to count matching pending runners as supply)
+// and internal/rebalancer (to compute per-label-set supply).
+func MatchesLabels(runnerLabels, jobLabels []string) bool {
+	have := make(map[string]struct{}, len(runnerLabels))
+	for _, l := range runnerLabels {
+		have[normalizeLabel(l)] = struct{}{}
+	}
+	for _, l := range jobLabels {
+		if _, ok := have[normalizeLabel(l)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizeLabel(s string) string {
+	out := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
+}

--- a/lambda/internal/state/state_test.go
+++ b/lambda/internal/state/state_test.go
@@ -1,0 +1,70 @@
+package state
+
+import "testing"
+
+func TestMatchesLabels(t *testing.T) {
+	cases := []struct {
+		name         string
+		runnerLabels []string
+		jobLabels    []string
+		want         bool
+	}{
+		{
+			name:         "exact match",
+			runnerLabels: []string{"self-hosted", "large"},
+			jobLabels:    []string{"self-hosted", "large"},
+			want:         true,
+		},
+		{
+			name:         "runner superset of job",
+			runnerLabels: []string{"self-hosted", "large", "x64"},
+			jobLabels:    []string{"self-hosted", "large"},
+			want:         true,
+		},
+		{
+			name:         "job has label runner does not",
+			runnerLabels: []string{"self-hosted", "large"},
+			jobLabels:    []string{"self-hosted", "large", "x64"},
+			want:         false,
+		},
+		{
+			name:         "case insensitive",
+			runnerLabels: []string{"Self-Hosted", "Large"},
+			jobLabels:    []string{"self-hosted", "large"},
+			want:         true,
+		},
+		{
+			name:         "ordering insensitive",
+			runnerLabels: []string{"large", "self-hosted"},
+			jobLabels:    []string{"self-hosted", "large"},
+			want:         true,
+		},
+		{
+			name:         "empty job labels: any runner matches",
+			runnerLabels: []string{"self-hosted"},
+			jobLabels:    []string{},
+			want:         true,
+		},
+		{
+			name:         "empty runner labels with non-empty job: false",
+			runnerLabels: []string{},
+			jobLabels:    []string{"self-hosted"},
+			want:         false,
+		},
+		{
+			name:         "completely disjoint",
+			runnerLabels: []string{"a", "b"},
+			jobLabels:    []string{"c", "d"},
+			want:         false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := MatchesLabels(tc.runnerLabels, tc.jobLabels)
+			if got != tc.want {
+				t.Errorf("MatchesLabels(%v, %v) = %v, want %v", tc.runnerLabels, tc.jobLabels, got, tc.want)
+			}
+		})
+	}
+}

--- a/lambda/internal/webhook/dispatcher.go
+++ b/lambda/internal/webhook/dispatcher.go
@@ -101,6 +101,7 @@ func (h *Handler) handleQueued(ctx context.Context, result *ParseResult) Respons
 		RepositoryFull: result.Event.Repository.FullName,
 		Labels:         result.Event.WorkflowJob.Labels,
 		InstallationID: result.Event.Installation.ID,
+		Source:         internalsqs.SourceWebhook,
 	}
 	if err := h.ScaleUpPublisher.PublishScaleUp(ctx, msg); err != nil {
 		return Response{Status: 500, Body: "Queue error"}

--- a/lambda/internal/webhook/dispatcher_test.go
+++ b/lambda/internal/webhook/dispatcher_test.go
@@ -98,6 +98,9 @@ func TestHandler_Handle_QueuedPublishesToScaleUp(t *testing.T) {
 	if scaleUp.last.EventAction != "queued" {
 		t.Errorf("scaleUp.EventAction = %q, want queued", scaleUp.last.EventAction)
 	}
+	if scaleUp.last.Source != internalsqs.SourceWebhook {
+		t.Errorf("Source = %q, want %q", scaleUp.last.Source, internalsqs.SourceWebhook)
+	}
 }
 
 func TestHandler_Handle_QueuedPublishError(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #62. Closes the stranded-queued-jobs drift cycle by making scaleup demand-aware and adding a periodic rebalancer Lambda that catches any drift the event-driven path misses.

- New `Source` field on `ScaleUpMessage` disambiguates webhook-fired vs rebalancer-fired messages.
- `scaleup.processRecord` inserts a demand check before `GenerateJITConfig`: webhook-source launches at most 1 if `demand > supply` (subset label match); rebalancer-source launches unconditionally (the rebalancer pre-counted the gap).
- New `rebalancer` Lambda fires every 1 minute via EventBridge, computes per-label-set `(demand - supply)` from GitHub queue + DDB pending, publishes that many `ScaleUpMessage`s with `Source="rebalancer"`.
- `ReservedConcurrentExecutions=1` on rebalancer prevents overlapping invocations.
- New `MatchesLabels` helper for case-/order-insensitive subset matching, shared by scaleup + rebalancer.
- New `github.ListQueuedWorkflowJobs` for demand discovery.

Targets `feat/gcp-support` (PR #46) since this work depends on `lambda/internal/aws/*` layout from the cloud-agnostic refactor.

Spec: zettelkasten `Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md`.
Plan: zettelkasten `Projects/jit-runners/plans/2026-05-02-effective-scaleup.md`.

## Test plan

- [x] `make check` clean: golangci-lint 0 issues, vet clean, ~155 tests pass.
- [x] New unit tests pin: `MatchesLabels` subset/superset/case/ordering; `ListQueuedWorkflowJobs` empty/single/filter/error; `shouldLaunch` source branching + subset match; `Rebalance` per-label-set accounting + error propagation.
- [ ] After merge: build all 5 Lambda zips locally, upload to \`s3://jit-runners-lambda-s3/v1.0.0-rc.4/\`, run \`aws cloudformation update-stack\`.
- [ ] Verify EventBridge rule fires every minute; rebalancer log shows \`cycle complete demand=N supply=M published=K\`.
- [ ] Force-push to PR #46 and observe within 10 minutes: zero stranded queued jobs.
- [ ] Cost check: total VM-hours for the same workload as a v1.0.0-rc.3 baseline ≤ 1.5×.

## Out of scope (follow-ups)

- Multi-installation / multi-repo rebalancing (current architecture is single-installation).
- Alarm wiring on rebalancer-emitted metrics (manual log query for now).
- Adaptive cadence (1-minute steady; revisit if drift reappears at scale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)