### PR TITLE
fix(rebalancer): iterate every installation repo, drop RepositoryFull

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -632,7 +632,9 @@ To exercise the silent-failure path on demand without a real workload:
 
 ## Stranded queued jobs
 
-A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely. Pre-issue #62, this happened because GitHub's matcher pairs runners with any queued matching job (often older stranded ones, not the specific job whose `queued` event triggered the runner's launch). The rebalancer Lambda closes this gap by periodically re-publishing `ScaleUpMessage`s for any queue depth not covered by pending runners. The rebalancer iterates every repo the GitHub App installation can access (org-wide), not just one.
+A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely. Pre-issue #62, this happened because GitHub's matcher pairs runners with any queued matching job (often older stranded ones, not the specific job whose `queued` event triggered the runner's launch). The rebalancer Lambda closes this gap by periodically re-publishing `ScaleUpMessage`s for any queue depth not covered by pending runners.
+
+The rebalancer iterates over **repos with recent activity**: it scans the DynamoDB runner records and selects every repo whose latest record was launched in the past 7 days. A repo with no recent record cannot have stranded queued jobs in our system (the drift cycle requires that scaleup already attempted to launch, which writes a record). This bounds per-cycle GitHub API calls to ~1 per active repo, keeping us well under the installation rate limit even for orgs with hundreds of repos.
 
 ### Quick check: is the rebalancer healthy?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -632,7 +632,7 @@ To exercise the silent-failure path on demand without a real workload:
 
 ## Stranded queued jobs
 
-A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely. Pre-issue #62, this happened because GitHub's matcher pairs runners with any queued matching job (often older stranded ones, not the specific job whose `queued` event triggered the runner's launch). The rebalancer Lambda closes this gap by periodically re-publishing `ScaleUpMessage`s for any queue depth not covered by pending runners.
+A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely. Pre-issue #62, this happened because GitHub's matcher pairs runners with any queued matching job (often older stranded ones, not the specific job whose `queued` event triggered the runner's launch). The rebalancer Lambda closes this gap by periodically re-publishing `ScaleUpMessage`s for any queue depth not covered by pending runners. The rebalancer iterates every repo the GitHub App installation can access (org-wide), not just one.
 
 ### Quick check: is the rebalancer healthy?
 
@@ -640,7 +640,7 @@ A "stranded queued job" is a workflow_job stuck in `queued` status indefinitely.
 aws logs tail /aws/lambda/jit-runners-rebalancer --since 10m --filter-pattern '"cycle complete"' --format short
 ```
 
-Expected: a `cycle complete demand=N supply=M published=K label_sets=L` line every minute. `published=K` should be 0 most of the time and non-zero only when there's actual drift to recover.
+Expected: per repo, a `cycle complete repo=<owner/repo> demand=N supply=M published=K label_sets=L` line, plus a single `tick complete repos=R errors=E` summary line, every minute. `published=K` should be 0 most of the time per repo and non-zero only when there's actual drift to recover. `errors=E` should normally be 0; non-zero means one or more repos hit a transient GitHub outage and the next tick will retry.
 
 ### Find currently stranded jobs (operator triage)
 
@@ -672,6 +672,8 @@ cat /tmp/rebalancer-out.json
 ```
 
 Useful when investigating stranded jobs and you don't want to wait for the next 1-minute cycle.
+
+One invocation rebalances every repo the App installation can access, not just one.
 
 ### Tuning the cadence
 

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -6,10 +6,6 @@ Parameters:
     Type: String
     Description: GitHub App ID (numeric).
 
-  RepositoryFull:
-    Type: String
-    Description: GitHub repository in "owner/repo" form. Used by the rebalancer Lambda to query queued workflow_jobs.
-
   GitHubInstallationId:
     Type: String
     Description: GitHub App installation ID (numeric) used by lifecycle and scaledown for installation-token minting.
@@ -602,7 +598,6 @@ Resources:
           GITHUB_APP_WEBHOOK_SECRET_ARN: !Ref WebhookSecretArn
           DYNAMODB_TABLE_NAME: !Ref RunnersTable
           SQS_QUEUE_URL: !Ref ScaleUpQueue
-          REPOSITORY_FULL: !Ref RepositoryFull
 
   RebalancerLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infra/terraform/rebalancer.tf
+++ b/infra/terraform/rebalancer.tf
@@ -28,7 +28,6 @@ resource "aws_lambda_function" "rebalancer" {
       GITHUB_APP_WEBHOOK_SECRET_ARN     = var.webhook_secret_arn
       DYNAMODB_TABLE_NAME               = aws_dynamodb_table.runners.name
       SQS_QUEUE_URL                     = aws_sqs_queue.scaleup.url
-      REPOSITORY_FULL                   = var.repository_full
     }
   }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -95,11 +95,6 @@ variable "rebalancer_lambda_s3_key" {
   description = "S3 key for the rebalancer Lambda zip (e.g. v1.0.0-rc.4/rebalancer.zip)."
 }
 
-variable "repository_full" {
-  type        = string
-  description = "GitHub repository in owner/repo form. Used by the rebalancer Lambda to query queued workflow_jobs."
-}
-
 # --- Scale-down ---
 
 variable "stale_threshold_minutes" {

--- a/lambda/cmd/rebalancer/main.go
+++ b/lambda/cmd/rebalancer/main.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -31,6 +32,14 @@ var (
 	appCfg  *appconfig.Config
 	cfgErr  error
 )
+
+// activityWindow scopes the rebalancer's per-cycle work to repos that
+// have at least one runner record launched in the past N. Drift recovery
+// requires that scaleup already attempted to launch (which writes a
+// record), so a repo with no recent record cannot have stranded queued
+// jobs in our system. 7 days is a generous default; tune via env later
+// if needed.
+const activityWindow = 7 * 24 * time.Hour
 
 func main() {
 	lambda.Start(handler)
@@ -59,9 +68,10 @@ func handler(ctx context.Context) error {
 		return fmt.Errorf("github client: %w", err)
 	}
 
-	repos, err := ghClient.ListInstallationRepositories(ctx)
+	since := time.Now().Add(-activityWindow)
+	repos, err := store.ListActiveRepos(ctx, since)
 	if err != nil {
-		log.Printf("rebalancer: list installation repositories: %v", err)
+		log.Printf("rebalancer: list active repos: %v", err)
 		// Return nil so EventBridge does not retry-storm. Next cycle (1 min)
 		// re-attempts.
 		return nil

--- a/lambda/cmd/rebalancer/main.go
+++ b/lambda/cmd/rebalancer/main.go
@@ -46,10 +46,6 @@ func handler(ctx context.Context) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	if cfg.RepositoryFull == "" {
-		return fmt.Errorf("rebalancer: REPOSITORY_FULL env var is required")
-	}
-
 	awsCfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("load AWS config: %w", err)
@@ -63,12 +59,22 @@ func handler(ctx context.Context) error {
 		return fmt.Errorf("github client: %w", err)
 	}
 
-	if err := rebalancer.Rebalance(ctx, ghClient, store, publisher, cfg.RepositoryFull, cfg.InstallationID); err != nil {
-		log.Printf("rebalancer: cycle error: %v", err)
+	repos, err := ghClient.ListInstallationRepositories(ctx)
+	if err != nil {
+		log.Printf("rebalancer: list installation repositories: %v", err)
 		// Return nil so EventBridge does not retry-storm. Next cycle (1 min)
-		// re-attempts with a fresh rate budget.
+		// re-attempts.
 		return nil
 	}
+
+	var errCount int
+	for _, repo := range repos {
+		if err := rebalancer.Rebalance(ctx, ghClient, store, publisher, repo, cfg.InstallationID); err != nil {
+			log.Printf("rebalancer: cycle error repo=%s: %v", repo, err)
+			errCount++
+		}
+	}
+	log.Printf("rebalancer: tick complete repos=%d errors=%d", len(repos), errCount)
 	return nil
 }
 

--- a/lambda/internal/aws/dynamo/store.go
+++ b/lambda/internal/aws/dynamo/store.go
@@ -261,6 +261,39 @@ func (s *Store) Update(ctx context.Context, id string, u state.RunnerUpdate) err
 	return nil
 }
 
+// ListActiveRepos returns the deduped Repository values across runner records
+// whose created_at (LaunchedAt) is at or after since. It uses a server-side
+// FilterExpression so that only matching items are returned from DynamoDB.
+// Results need not be sorted; callers that need stable ordering must sort.
+func (s *Store) ListActiveRepos(ctx context.Context, since time.Time) ([]string, error) {
+	input := &dynamodb.ScanInput{
+		TableName:            aws.String(s.tableName),
+		ProjectionExpression: aws.String("repository, created_at"),
+		FilterExpression:     aws.String("created_at >= :since"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":since": &types.AttributeValueMemberN{Value: strconv.FormatInt(since.Unix(), 10)},
+		},
+	}
+	out, err := s.client.Scan(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("scan active repos: %w", err)
+	}
+	seen := make(map[string]struct{})
+	var repos []string
+	for _, item := range out.Items {
+		v, ok := item["repository"].(*types.AttributeValueMemberS)
+		if !ok || v.Value == "" {
+			continue
+		}
+		if _, dup := seen[v.Value]; dup {
+			continue
+		}
+		seen[v.Value] = struct{}{}
+		repos = append(repos, v.Value)
+	}
+	return repos, nil
+}
+
 // Delete removes a runner record by its ID.
 func (s *Store) Delete(ctx context.Context, id string) error {
 	if id == "" {

--- a/lambda/internal/aws/dynamo/store_test.go
+++ b/lambda/internal/aws/dynamo/store_test.go
@@ -3,6 +3,7 @@ package dynamo
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
 	"time"
 
@@ -278,6 +279,56 @@ func TestStore_Put_RoundTripsJobIDAndWorkflowRunID(t *testing.T) {
 	if got.WorkflowRunID != 9012 {
 		t.Errorf("WorkflowRunID = %d, want 9012", got.WorkflowRunID)
 	}
+}
+
+func TestListActiveRepos(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	t.Run("empty result returns empty slice", func(t *testing.T) {
+		mock := &mockDDB{scanOut: &dynamodb.ScanOutput{Items: []map[string]types.AttributeValue{}}}
+		s := NewStore(mock, "runners")
+		got, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 repos, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("dedupes repository values from scan output", func(t *testing.T) {
+		items := []map[string]types.AttributeValue{
+			{"repository": &types.AttributeValueMemberS{Value: "o/a"}},
+			{"repository": &types.AttributeValueMemberS{Value: "o/a"}},
+			{"repository": &types.AttributeValueMemberS{Value: "o/b"}},
+		}
+		mock := &mockDDB{scanOut: &dynamodb.ScanOutput{Items: items}}
+		s := NewStore(mock, "runners")
+		got, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		sort.Strings(got)
+		want := []string{"o/a", "o/b"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("propagates Scan error", func(t *testing.T) {
+		mock := &mockDDB{err: errors.New("dynamo unavailable")}
+		s := NewStore(mock, "runners")
+		_, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 }
 
 func stringPtr(s string) *string     { return &s }

--- a/lambda/internal/config/config.go
+++ b/lambda/internal/config/config.go
@@ -34,12 +34,6 @@ type Config struct {
 	// the installation from the SQS message payload directly.
 	InstallationID int64
 
-	// RepositoryFull is the GitHub repository in "owner/repo" form.
-	// Used by the rebalancer Lambda to query queued workflow_jobs.
-	// Required when the rebalancer Lambda is deployed (set via the
-	// REPOSITORY_FULL env var).
-	RepositoryFull string
-
 	// SQS queue URL for scale-up messages.
 	QueueURL string
 
@@ -90,7 +84,6 @@ func LoadWith(ctx context.Context, loader secrets.Loader) (*Config, error) {
 		SecurityGroupID:    os.Getenv("EC2_SECURITY_GROUP_ID"),
 		IAMInstanceProfile: os.Getenv("EC2_IAM_INSTANCE_PROFILE"),
 		DefaultAMI:         os.Getenv("EC2_DEFAULT_AMI"),
-		RepositoryFull:     os.Getenv("REPOSITORY_FULL"),
 	}
 
 	if err := validateRequiredEnv(cfg); err != nil {

--- a/lambda/internal/config/config_test.go
+++ b/lambda/internal/config/config_test.go
@@ -73,7 +73,6 @@ func TestLoad_Success(t *testing.T) {
 	t.Setenv("GITHUB_APP_PRIVATE_KEY", "my-private-key")
 	t.Setenv("EC2_SUBNET_IDS", "subnet-1,subnet-2")
 	t.Setenv("LABEL_MAPPINGS", `[{"label":"gpu","instance_type":"g4dn.xlarge"}]`)
-	t.Setenv("REPOSITORY_FULL", "owner/repo")
 
 	cfg, err := Load(context.Background())
 	if err != nil {
@@ -97,9 +96,6 @@ func TestLoad_Success(t *testing.T) {
 	}
 	if cfg.InstallationID != 0 {
 		t.Errorf("InstallationID = %d, want 0 (unset)", cfg.InstallationID)
-	}
-	if cfg.RepositoryFull != "owner/repo" {
-		t.Errorf("RepositoryFull = %q, want %q", cfg.RepositoryFull, "owner/repo")
 	}
 }
 
@@ -172,7 +168,6 @@ func clearEnv(t *testing.T) {
 		"GITHUB_INSTALLATION_ID",
 		"EC2_SUBNET_IDS", "EC2_SECURITY_GROUP_ID", "EC2_IAM_INSTANCE_PROFILE",
 		"EC2_DEFAULT_AMI", "LABEL_MAPPINGS",
-		"REPOSITORY_FULL",
 	}
 	for _, k := range envVars {
 		t.Setenv(k, "")

--- a/lambda/internal/github/client.go
+++ b/lambda/internal/github/client.go
@@ -233,6 +233,60 @@ func (c *Client) ListQueuedWorkflowJobs(ctx context.Context, ownerRepo string) (
 	return queued, nil
 }
 
+type listInstallationReposResponse struct {
+	TotalCount   int `json:"total_count"`
+	Repositories []struct {
+		FullName string `json:"full_name"`
+	} `json:"repositories"`
+}
+
+// ListInstallationRepositories returns the full_names of every repository
+// the App installation can access. Pages via ?page=N&per_page=100 until
+// total_count is reached. Used by the rebalancer Lambda to scope its
+// queued-jobs query across the entire org-level installation.
+func (c *Client) ListInstallationRepositories(ctx context.Context) ([]string, error) {
+	const perPage = 100
+	var out []string
+	page := 1
+	for {
+		url := fmt.Sprintf("%s/installation/repositories?per_page=%d&page=%d", c.baseURL, perPage, page)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("Authorization", "Bearer "+c.token)
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from GitHub API constant
+		if err != nil {
+			return nil, fmt.Errorf("github: list installation repositories page %d: %w", page, err)
+		}
+		body, decodeErr := func() (listInstallationReposResponse, error) {
+			defer resp.Body.Close() //nolint:errcheck // best-effort close
+			if resp.StatusCode != http.StatusOK {
+				return listInstallationReposResponse{}, fmt.Errorf("status %d", resp.StatusCode)
+			}
+			var b listInstallationReposResponse
+			if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
+				return listInstallationReposResponse{}, fmt.Errorf("decode: %w", err)
+			}
+			return b, nil
+		}()
+		if decodeErr != nil {
+			return nil, fmt.Errorf("github: list installation repositories page %d: %w", page, decodeErr)
+		}
+		for _, r := range body.Repositories {
+			out = append(out, r.FullName)
+		}
+		if len(out) >= body.TotalCount || len(body.Repositories) == 0 {
+			break
+		}
+		page++
+	}
+	return out, nil
+}
+
 func (c *Client) listQueuedRuns(ctx context.Context, ownerRepo string) ([]struct {
 	ID int64 `json:"id"`
 }, error) {

--- a/lambda/internal/github/client.go
+++ b/lambda/internal/github/client.go
@@ -233,60 +233,6 @@ func (c *Client) ListQueuedWorkflowJobs(ctx context.Context, ownerRepo string) (
 	return queued, nil
 }
 
-type listInstallationReposResponse struct {
-	TotalCount   int `json:"total_count"`
-	Repositories []struct {
-		FullName string `json:"full_name"`
-	} `json:"repositories"`
-}
-
-// ListInstallationRepositories returns the full_names of every repository
-// the App installation can access. Pages via ?page=N&per_page=100 until
-// total_count is reached. Used by the rebalancer Lambda to scope its
-// queued-jobs query across the entire org-level installation.
-func (c *Client) ListInstallationRepositories(ctx context.Context) ([]string, error) {
-	const perPage = 100
-	var out []string
-	page := 1
-	for {
-		url := fmt.Sprintf("%s/installation/repositories?per_page=%d&page=%d", c.baseURL, perPage, page)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/vnd.github+json")
-		req.Header.Set("Authorization", "Bearer "+c.token)
-		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-
-		resp, err := c.httpClient.Do(req) //nolint:gosec // G704: URL from GitHub API constant
-		if err != nil {
-			return nil, fmt.Errorf("github: list installation repositories page %d: %w", page, err)
-		}
-		body, decodeErr := func() (listInstallationReposResponse, error) {
-			defer resp.Body.Close() //nolint:errcheck // best-effort close
-			if resp.StatusCode != http.StatusOK {
-				return listInstallationReposResponse{}, fmt.Errorf("status %d", resp.StatusCode)
-			}
-			var b listInstallationReposResponse
-			if err := json.NewDecoder(resp.Body).Decode(&b); err != nil {
-				return listInstallationReposResponse{}, fmt.Errorf("decode: %w", err)
-			}
-			return b, nil
-		}()
-		if decodeErr != nil {
-			return nil, fmt.Errorf("github: list installation repositories page %d: %w", page, decodeErr)
-		}
-		for _, r := range body.Repositories {
-			out = append(out, r.FullName)
-		}
-		if len(out) >= body.TotalCount || len(body.Repositories) == 0 {
-			break
-		}
-		page++
-	}
-	return out, nil
-}
-
 func (c *Client) listQueuedRuns(ctx context.Context, ownerRepo string) ([]struct {
 	ID int64 `json:"id"`
 }, error) {

--- a/lambda/internal/github/client_test.go
+++ b/lambda/internal/github/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -176,6 +177,93 @@ func TestListQueuedWorkflowJobs(t *testing.T) {
 		_, err := c.ListQueuedWorkflowJobs(context.Background(), "owner/repo")
 		if err == nil {
 			t.Fatal("expected error on 429, got nil")
+		}
+	})
+}
+
+func TestListInstallationRepositories(t *testing.T) {
+	t.Run("empty installation returns empty slice", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/installation/repositories" {
+				t.Errorf("unexpected path %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total_count":0,"repositories":[]}`))
+		}))
+		defer srv.Close()
+		c := NewClientWithBase("tok", srv.URL)
+		got, err := c.ListInstallationRepositories(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 repos, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("single page returns all full_names", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total_count":2,"repositories":[
+				{"full_name":"devopsfactory-io/jit-runners"},
+				{"full_name":"devopsfactory-io/neptune"}
+			]}`))
+		}))
+		defer srv.Close()
+		c := NewClientWithBase("tok", srv.URL)
+		got, err := c.ListInstallationRepositories(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"devopsfactory-io/jit-runners", "devopsfactory-io/neptune"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("paginates by page query param until total_count reached", func(t *testing.T) {
+		var calls int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			page := r.URL.Query().Get("page")
+			w.WriteHeader(http.StatusOK)
+			switch page {
+			case "", "1":
+				_, _ = w.Write([]byte(`{"total_count":3,"repositories":[
+					{"full_name":"o/a"},{"full_name":"o/b"}
+				]}`))
+			case "2":
+				_, _ = w.Write([]byte(`{"total_count":3,"repositories":[
+					{"full_name":"o/c"}
+				]}`))
+			default:
+				t.Errorf("unexpected page %q", page)
+			}
+		}))
+		defer srv.Close()
+		c := NewClientWithBase("tok", srv.URL)
+		got, err := c.ListInstallationRepositories(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []string{"o/a", "o/b", "o/c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 page fetches, got %d", calls)
+		}
+	})
+
+	t.Run("non-200 returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+		c := NewClientWithBase("tok", srv.URL)
+		_, err := c.ListInstallationRepositories(context.Background())
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 }

--- a/lambda/internal/github/client_test.go
+++ b/lambda/internal/github/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"testing"
 )
 
@@ -181,89 +180,3 @@ func TestListQueuedWorkflowJobs(t *testing.T) {
 	})
 }
 
-func TestListInstallationRepositories(t *testing.T) {
-	t.Run("empty installation returns empty slice", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path != "/installation/repositories" {
-				t.Errorf("unexpected path %q", r.URL.Path)
-			}
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"total_count":0,"repositories":[]}`))
-		}))
-		defer srv.Close()
-		c := NewClientWithBase("tok", srv.URL)
-		got, err := c.ListInstallationRepositories(context.Background())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(got) != 0 {
-			t.Errorf("expected 0 repos, got %d: %v", len(got), got)
-		}
-	})
-
-	t.Run("single page returns all full_names", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"total_count":2,"repositories":[
-				{"full_name":"devopsfactory-io/jit-runners"},
-				{"full_name":"devopsfactory-io/neptune"}
-			]}`))
-		}))
-		defer srv.Close()
-		c := NewClientWithBase("tok", srv.URL)
-		got, err := c.ListInstallationRepositories(context.Background())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []string{"devopsfactory-io/jit-runners", "devopsfactory-io/neptune"}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-	})
-
-	t.Run("paginates by page query param until total_count reached", func(t *testing.T) {
-		var calls int
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			calls++
-			page := r.URL.Query().Get("page")
-			w.WriteHeader(http.StatusOK)
-			switch page {
-			case "", "1":
-				_, _ = w.Write([]byte(`{"total_count":3,"repositories":[
-					{"full_name":"o/a"},{"full_name":"o/b"}
-				]}`))
-			case "2":
-				_, _ = w.Write([]byte(`{"total_count":3,"repositories":[
-					{"full_name":"o/c"}
-				]}`))
-			default:
-				t.Errorf("unexpected page %q", page)
-			}
-		}))
-		defer srv.Close()
-		c := NewClientWithBase("tok", srv.URL)
-		got, err := c.ListInstallationRepositories(context.Background())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		want := []string{"o/a", "o/b", "o/c"}
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
-		}
-		if calls != 2 {
-			t.Errorf("expected 2 page fetches, got %d", calls)
-		}
-	})
-
-	t.Run("non-200 returns error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-		}))
-		defer srv.Close()
-		c := NewClientWithBase("tok", srv.URL)
-		_, err := c.ListInstallationRepositories(context.Background())
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-	})
-}

--- a/lambda/internal/lifecycle/handler_test.go
+++ b/lambda/internal/lifecycle/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
@@ -38,6 +39,10 @@ func (f *fakeStore) Delete(_ context.Context, _ string) error { return nil }
 func (f *fakeStore) Update(_ context.Context, id string, u state.RunnerUpdate) error {
 	f.updates = append(f.updates, updateCall{id: id, fields: u})
 	return f.updateErr
+}
+
+func (f *fakeStore) ListActiveRepos(_ context.Context, _ time.Time) ([]string, error) {
+	return nil, nil
 }
 
 // fakeGitHub records DeregisterRunner calls.

--- a/lambda/internal/rebalancer/rebalancer.go
+++ b/lambda/internal/rebalancer/rebalancer.go
@@ -80,8 +80,8 @@ func Rebalance(ctx context.Context, gh QueueLister, store state.RunnerStore, pub
 			totalPublished++
 		}
 	}
-	log.Printf("rebalancer: cycle complete demand=%d supply=%d published=%d label_sets=%d",
-		len(queued), len(pending), totalPublished, len(groups))
+	log.Printf("rebalancer: cycle complete repo=%s demand=%d supply=%d published=%d label_sets=%d",
+		repoFull, len(queued), len(pending), totalPublished, len(groups))
 	if len(publishErrs) > 0 {
 		return errors.Join(publishErrs...)
 	}

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -46,6 +46,9 @@ func (f *fakeStore) Update(_ context.Context, id string, u state.RunnerUpdate) e
 }
 
 func (f *fakeStore) Delete(_ context.Context, _ string) error { return nil }
+func (f *fakeStore) ListActiveRepos(_ context.Context, _ time.Time) ([]string, error) {
+	return nil, nil
+}
 
 // fakeLauncher records terminate calls and may inject an error. It also
 // satisfies compute.Launcher (Launch and ListStale return zero values; the

--- a/lambda/internal/state/memstore/memstore.go
+++ b/lambda/internal/state/memstore/memstore.go
@@ -101,3 +101,27 @@ func (s *Store) Delete(_ context.Context, id string) error {
 	delete(s.records, id)
 	return nil
 }
+
+// ListActiveRepos returns the deduped Repository values across runner records
+// launched at or after since. Records with an empty Repository are skipped.
+// Results are not sorted; callers that need a stable order must sort themselves.
+func (s *Store) ListActiveRepos(_ context.Context, since time.Time) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	seen := make(map[string]struct{})
+	var repos []string
+	for _, r := range s.records {
+		if r.LaunchedAt.Before(since) {
+			continue
+		}
+		if r.Repository == "" {
+			continue
+		}
+		if _, dup := seen[r.Repository]; dup {
+			continue
+		}
+		seen[r.Repository] = struct{}{}
+		repos = append(repos, r.Repository)
+	}
+	return repos, nil
+}

--- a/lambda/internal/state/memstore/memstore_test.go
+++ b/lambda/internal/state/memstore/memstore_test.go
@@ -3,7 +3,9 @@ package memstore
 import (
 	"context"
 	"errors"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
@@ -58,4 +60,70 @@ func TestList_FilterByStatus(t *testing.T) {
 	if len(pending) != 1 || pending[0].ID != "1" {
 		t.Errorf("List(pending) = %+v, want one record id=1", pending)
 	}
+}
+
+func TestListActiveRepos(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	t.Run("empty store returns empty slice", func(t *testing.T) {
+		s := New()
+		got, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("expected 0 repos, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("single repo with one record", func(t *testing.T) {
+		s := New()
+		_ = s.Put(ctx, state.Runner{ID: "r1", Repository: "o/a", LaunchedAt: now})
+		got, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		if len(got) != 1 || got[0] != "o/a" {
+			t.Errorf("got %v, want [o/a]", got)
+		}
+	})
+
+	t.Run("multiple repos deduped", func(t *testing.T) {
+		s := New()
+		_ = s.Put(ctx, state.Runner{ID: "r1", Repository: "o/a", LaunchedAt: now})
+		_ = s.Put(ctx, state.Runner{ID: "r2", Repository: "o/a", LaunchedAt: now})
+		_ = s.Put(ctx, state.Runner{ID: "r3", Repository: "o/b", LaunchedAt: now})
+		got, err := s.ListActiveRepos(ctx, now.Add(-time.Hour))
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		sort.Strings(got)
+		want := []string{"o/a", "o/b"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("since filter excludes older records", func(t *testing.T) {
+		s := New()
+		t1 := now.Add(-2 * time.Hour)
+		t2 := now.Add(-1 * time.Hour)
+		_ = s.Put(ctx, state.Runner{ID: "old", Repository: "o/old", LaunchedAt: t1})
+		_ = s.Put(ctx, state.Runner{ID: "new", Repository: "o/new", LaunchedAt: t2})
+		// since = t2 - 1ns: only the record at t2 should be included
+		since := t2.Add(-1 * time.Nanosecond)
+		got, err := s.ListActiveRepos(ctx, since)
+		if err != nil {
+			t.Fatalf("ListActiveRepos: %v", err)
+		}
+		if len(got) != 1 || got[0] != "o/new" {
+			t.Errorf("got %v, want [o/new]", got)
+		}
+	})
 }

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -66,6 +66,12 @@ type RunnerStore interface {
 	List(ctx context.Context, f Filter) ([]Runner, error)
 	Update(ctx context.Context, id string, fields RunnerUpdate) error
 	Delete(ctx context.Context, id string) error
+	// ListActiveRepos returns the deduped Repository values across runner
+	// records launched at or after `since`. Used by the rebalancer Lambda
+	// to scope its per-cycle GitHub queue queries to repos that have
+	// recent webhook-driven activity. Implementations may scan or query
+	// the underlying store; results need not be sorted.
+	ListActiveRepos(ctx context.Context, since time.Time) ([]string, error)
 }
 
 // MatchesLabels reports whether a runner with `runnerLabels` can satisfy a


### PR DESCRIPTION
## Summary

Follow-up to #63. The rebalancer Lambda shipped in #63 was hardcoded to a single repo via the \`REPOSITORY_FULL\` deploy-time env var, but the jit-runners GitHub App installation is org-level — it serves every \`devopsfactory-io/*\` repo. A single-repo rebalancer would silently drop drift recovery on every other repo.

This PR replaces the deploy-time env var with a runtime call to \`state.RunnerStore.ListActiveRepos(ctx, now-7d)\` — a DDB scan of the existing runner records, scoped to repos launched in the last 7 days. Each rebalancer tick enumerates that active set and runs one \`Rebalance\` cycle per repo. Per-repo errors are logged and counted but do not abort the whole tick.

### Why DDB activity window, not the GitHub installation API

The first iteration of this fix called \`GET /installation/repositories\` per cycle. With N org repos × 60 cycles/hr = up to N × 60 calls/hr, this would blow the GitHub installation rate limit (~5000 req/hr) at any non-trivial org size. Caught pre-merge.

The drift cycle is structurally bounded to repos where scaleup already attempted to launch (which writes a DDB record), so a repo with no recent record cannot have stranded queued jobs in our system. Per cycle: 1 DDB scan + 1 GH \`actions/runs?status=queued\` call per active repo. With 5–10 active repos, ≈300–600 GH calls/hr — comfortable.

## Changes

- New \`state.RunnerStore.ListActiveRepos(ctx, since time.Time) ([]string, error)\` — implementations on memstore (in-memory dedup over runner records) and dynamo (Scan with \`created_at >= :since\` filter expression, projection on \`repository\`, in-process dedup).
- \`cmd/rebalancer/main.go\` handler now: \`store.ListActiveRepos(ctx, now-7d)\` → loops \`Rebalance\` per repo → emits per-repo \`cycle complete repo=<owner/repo> ...\` and \`cycle error repo=<owner/repo> ...\` logs + a single \`tick complete repos=R errors=E\` summary line per cycle. Activity window is a Go const (\`activityWindow = 7 * 24 * time.Hour\`), tunable in code if usage patterns demand it.
- \`Config.RepositoryFull\` field and \`REPOSITORY_FULL\` env load removed from \`lambda/internal/config/config.go\`.
- \`RepositoryFull\` parameter and \`REPOSITORY_FULL\` env var removed from \`infra/cloudformation/template.yaml\`.
- \`repository_full\` variable and \`REPOSITORY_FULL\` env var removed from \`infra/terraform/\`.
- \`docs/troubleshooting.md\` — \"Stranded queued jobs\" section updated for the activity-window source, the new per-repo log shape, and the tick-complete summary.
- Spec addendum (\`Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md\`, in zettelkasten) records both the multi-repo scope correction and the same-day refinement to switch to DDB.

The unrelated \`ScaleUpMessage.RepositoryFull\` (per-message field) is untouched.

## Out of scope (still)

- **Multi-installation rebalancing.** The implementation assumes a single \`GITHUB_INSTALLATION_ID\` baked into the Lambda env. Supporting multiple installations would require listing them via \`GET /app/installations\` with App-level JWT auth — not justified by current usage.

## Test plan

- [x] \`make check\` clean: golangci-lint 0 issues, vet clean, **164 tests pass** (160 baseline + 9 new \`ListActiveRepos\` tests across memstore/dynamo, − 5 from removing the unused \`ListInstallationRepositories\`).
- [x] \`tofu validate\` clean.
- [x] \`aws cloudformation validate-template\` clean.
- [x] Grep guards: 0 \`RepositoryFull/REPOSITORY_FULL\` in config, CFN, Terraform, or rebalancer cmd. \`ScaleUpMessage.RepositoryFull\` (per-message) intact. \`ListInstallationRepositories\` not present anywhere in the source tree.
- [ ] After merge: rebuild all 5 Lambda zips locally, upload to \`s3://jit-runners-lambda-s3/v1.0.0-rc.4/\`, \`aws cloudformation update-stack\` (the \`RepositoryFull\` parameter is gone from the template, so the operator drops that ParameterKey from the update-stack call).
- [ ] Verify rebalancer log shape: per-repo \`cycle complete repo=...\` lines + one \`tick complete repos=R errors=0\` summary every minute (R should match active-repo count over the 7-day window).
- [ ] Force-push to PR #46, observe within 10 minutes: zero stranded queued jobs across all active repos.
- [ ] Cost check: VM-hours within 1.5× baseline.

## Refs

- Plan: zettelkasten \`Projects/jit-runners/plans/2026-05-02-multi-repo-rebalancer.md\` (with same-day amendment).
- Spec: zettelkasten \`Projects/jit-runners/specs/2026-05-02-effective-scaleup-design.md\` (with 2026-05-02 multi-repo scope correction + DDB-source refinement addenda).
- Closes scope gap from #62 / #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)