### PR TITLE
feat(terraform-gcp): Phase D-Terraform — infra/terraform-gcp/ module

### DIFF
--- a/infra/terraform-gcp/eventarc.tf
+++ b/infra/terraform-gcp/eventarc.tf
@@ -1,0 +1,91 @@
+# ============================================================================
+# Eventarc Pub/Sub triggers (D3)
+#
+# Each trigger:
+#   - Matches on Pub/Sub messagePublished events.
+#   - References the underlying topic via transport.pubsub.topic.
+#   - Targets a Cloud Run function via destination.cloud_run_service.
+#   - Uses the eventarc-invoker SA for OIDC auth into the function.
+#
+# Per D13, whether the trigger binds to the explicit subscription declared
+# in pubsub.tf or auto-creates its own is a runtime concern. Verification
+# step: `gcloud eventarc triggers describe <trigger>` after first apply.
+# ============================================================================
+
+# Eventarc-invoker SA needs roles/run.invoker on each target function.
+# We declare those bindings here so the trigger creation succeeds (Eventarc
+# verifies invoker permission at trigger-create time).
+
+resource "google_cloud_run_v2_service_iam_member" "eventarc_invokes_scaleup" {
+  project  = var.gcp_project
+  location = var.gcp_region
+  name     = google_cloudfunctions2_function.scaleup.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.eventarc_invoker.email}"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "eventarc_invokes_lifecycle" {
+  project  = var.gcp_project
+  location = var.gcp_region
+  name     = google_cloudfunctions2_function.lifecycle.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.eventarc_invoker.email}"
+}
+
+# scaleup trigger: jobs topic → scaleup function
+
+resource "google_eventarc_trigger" "scaleup" {
+  name     = "${var.prefix}-scaleup"
+  location = var.gcp_region
+
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.pubsub.topic.v1.messagePublished"
+  }
+
+  transport {
+    pubsub {
+      topic = google_pubsub_topic.jobs.id
+    }
+  }
+
+  destination {
+    cloud_run_service {
+      service = google_cloudfunctions2_function.scaleup.name
+      region  = var.gcp_region
+    }
+  }
+
+  service_account = google_service_account.eventarc_invoker.email
+
+  depends_on = [google_cloud_run_v2_service_iam_member.eventarc_invokes_scaleup]
+}
+
+# lifecycle trigger: lifecycle topic → lifecycle function
+
+resource "google_eventarc_trigger" "lifecycle" {
+  name     = "${var.prefix}-lifecycle"
+  location = var.gcp_region
+
+  matching_criteria {
+    attribute = "type"
+    value     = "google.cloud.pubsub.topic.v1.messagePublished"
+  }
+
+  transport {
+    pubsub {
+      topic = google_pubsub_topic.lifecycle.id
+    }
+  }
+
+  destination {
+    cloud_run_service {
+      service = google_cloudfunctions2_function.lifecycle.name
+      region  = var.gcp_region
+    }
+  }
+
+  service_account = google_service_account.eventarc_invoker.email
+
+  depends_on = [google_cloud_run_v2_service_iam_member.eventarc_invokes_lifecycle]
+}

--- a/infra/terraform-gcp/firestore.tf
+++ b/infra/terraform-gcp/firestore.tf
@@ -1,0 +1,44 @@
+# ============================================================================
+# Firestore database (D12 — feature flag for greenfield bootstrap)
+#
+# When create_firestore_database = true:
+#   - Creates the (default) Firestore Native database in var.gcp_region.
+#   - delete_protection_state = DISABLED + deletion_policy = DELETE so
+#     `terraform destroy` works on the rest of the module without orphaning.
+#
+# When create_firestore_database = false (default):
+#   - This resource is skipped entirely; the module assumes the project
+#     already has a (default) Firestore database. The TTL field policy
+#     below references "(default)" by hard-coded name and works either way.
+# ============================================================================
+
+resource "google_firestore_database" "default" {
+  count = var.create_firestore_database ? 1 : 0
+
+  project                 = var.gcp_project
+  name                    = "(default)"
+  location_id             = var.gcp_region
+  type                    = "FIRESTORE_NATIVE"
+  delete_protection_state = "DELETE_PROTECTION_DISABLED"
+  deletion_policy         = "DELETE"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ============================================================================
+# TTL field policy
+#
+# Auto-deletes runner records once their `ttl` field's timestamp passes.
+# Set by scaleup at runner creation time; mirrors AWS DynamoDB TTL.
+# ============================================================================
+
+resource "google_firestore_field" "runners_ttl" {
+  project    = var.gcp_project
+  database   = "(default)"
+  collection = var.firestore_collection
+  field      = "ttl"
+
+  ttl_config {}
+
+  depends_on = [google_firestore_database.default]
+}

--- a/infra/terraform-gcp/functions.tf
+++ b/infra/terraform-gcp/functions.tf
@@ -1,0 +1,278 @@
+# ============================================================================
+# Cloud Run functions Gen 2 (D10)
+#
+# Five functions: webhook, scaleup, scaledown, lifecycle, rebalancer.
+# All consume their source zip from the GCS bucket populated by storage.tf
+# (which itself fetches from GitHub Releases per D11).
+#
+# Per-function knobs differ:
+#   - webhook: ingress=ALLOW_ALL (public-facing; HMAC verify is the trust boundary)
+#   - scaleup, lifecycle: ingress=ALLOW_INTERNAL_ONLY (Eventarc-only)
+#   - scaledown, rebalancer: ingress=ALLOW_INTERNAL_ONLY (Cloud Scheduler-only)
+#   - max_instance_count: 1 for scaledown + rebalancer (serial execution),
+#     var.max_instance_count for the others
+# ============================================================================
+
+# ----------------------------------------------------------------------------
+# webhook — public HTTPS endpoint, publishes workflow_job events to Pub/Sub
+# ----------------------------------------------------------------------------
+
+resource "google_cloudfunctions2_function" "webhook" {
+  name     = "${var.prefix}-webhook"
+  location = var.gcp_region
+
+  build_config {
+    runtime     = "go122"
+    entry_point = "Handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.function_zip["webhook"].name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = var.function_memory
+    timeout_seconds       = var.function_timeout_seconds
+    max_instance_count    = var.max_instance_count
+    ingress_settings      = "ALLOW_ALL"
+    service_account_email = google_service_account.webhook.email
+
+    environment_variables = {
+      CLOUD_PROVIDER         = "gcp"
+      GCP_PROJECT            = var.gcp_project
+      GCP_REGION             = var.gcp_region
+      PUBSUB_JOBS_TOPIC      = google_pubsub_topic.jobs.id
+      PUBSUB_LIFECYCLE_TOPIC = google_pubsub_topic.lifecycle.id
+      LOG_LEVEL              = "info"
+    }
+
+    secret_environment_variables {
+      key        = "WEBHOOK_SECRET"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.webhook_secret.secret_id
+      version    = "latest"
+    }
+
+    secret_environment_variables {
+      key        = "GITHUB_APP_KEY"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.github_app_key.secret_id
+      version    = "latest"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ----------------------------------------------------------------------------
+# scaleup — Eventarc-triggered; consumes jobs topic; launches GCE VMs
+# ----------------------------------------------------------------------------
+
+resource "google_cloudfunctions2_function" "scaleup" {
+  name     = "${var.prefix}-scaleup"
+  location = var.gcp_region
+
+  build_config {
+    runtime     = "go122"
+    entry_point = "Handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.function_zip["scaleup"].name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = var.function_memory
+    timeout_seconds       = var.function_timeout_seconds
+    max_instance_count    = var.max_instance_count
+    ingress_settings      = "ALLOW_INTERNAL_ONLY"
+    service_account_email = google_service_account.scaleup.email
+
+    environment_variables = {
+      CLOUD_PROVIDER          = "gcp"
+      GCP_PROJECT             = var.gcp_project
+      GCP_REGION              = var.gcp_region
+      GITHUB_APP_ID           = var.github_app_id
+      GITHUB_INSTALLATION_ID  = var.github_installation_id
+      PUBSUB_JOBS_TOPIC       = google_pubsub_topic.jobs.id
+      FIRESTORE_DATABASE      = "(default)"
+      FIRESTORE_COLLECTION    = var.firestore_collection
+      RUNNER_NETWORK          = var.runner_network
+      RUNNER_SUBNET           = var.runner_subnet
+      RUNNER_IMAGE            = var.runner_image
+      RUNNER_SA_EMAIL         = google_service_account.runner.email
+      RUNNER_ZONE             = var.runner_zone
+      LABEL_MAPPINGS          = var.label_mappings
+      MAX_RE_ENQUEUE_ATTEMPTS = tostring(var.max_re_enqueue_attempts)
+      LOG_LEVEL               = "info"
+    }
+
+    secret_environment_variables {
+      key        = "GITHUB_APP_KEY"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.github_app_key.secret_id
+      version    = "latest"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ----------------------------------------------------------------------------
+# scaledown — Cloud-Scheduler-triggered every 5 min; cleanup + re-enqueue
+# ----------------------------------------------------------------------------
+
+resource "google_cloudfunctions2_function" "scaledown" {
+  name     = "${var.prefix}-scaledown"
+  location = var.gcp_region
+
+  build_config {
+    runtime     = "go122"
+    entry_point = "Handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.function_zip["scaledown"].name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = var.function_memory
+    timeout_seconds       = var.function_timeout_seconds
+    max_instance_count    = 1
+    ingress_settings      = "ALLOW_INTERNAL_ONLY"
+    service_account_email = google_service_account.scaledown.email
+
+    environment_variables = {
+      CLOUD_PROVIDER          = "gcp"
+      GCP_PROJECT             = var.gcp_project
+      GCP_REGION              = var.gcp_region
+      GITHUB_APP_ID           = var.github_app_id
+      GITHUB_INSTALLATION_ID  = var.github_installation_id
+      PUBSUB_JOBS_TOPIC       = google_pubsub_topic.jobs.id
+      FIRESTORE_DATABASE      = "(default)"
+      FIRESTORE_COLLECTION    = var.firestore_collection
+      RUNNER_ZONE             = var.runner_zone
+      MAX_RUNNER_AGE_MINUTES  = tostring(var.max_runner_age_minutes)
+      STALE_THRESHOLD_MINUTES = tostring(var.stale_threshold_minutes)
+      MAX_RE_ENQUEUE_ATTEMPTS = tostring(var.max_re_enqueue_attempts)
+      LOG_LEVEL               = "info"
+    }
+
+    secret_environment_variables {
+      key        = "GITHUB_APP_KEY"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.github_app_key.secret_id
+      version    = "latest"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ----------------------------------------------------------------------------
+# lifecycle — Eventarc-triggered; processes workflow_job in_progress/completed
+# ----------------------------------------------------------------------------
+
+resource "google_cloudfunctions2_function" "lifecycle" {
+  name     = "${var.prefix}-lifecycle"
+  location = var.gcp_region
+
+  build_config {
+    runtime     = "go122"
+    entry_point = "Handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.function_zip["lifecycle"].name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = var.function_memory
+    timeout_seconds       = var.function_timeout_seconds
+    max_instance_count    = var.max_instance_count
+    ingress_settings      = "ALLOW_INTERNAL_ONLY"
+    service_account_email = google_service_account.lifecycle.email
+
+    environment_variables = {
+      CLOUD_PROVIDER         = "gcp"
+      GCP_PROJECT            = var.gcp_project
+      GCP_REGION             = var.gcp_region
+      GITHUB_APP_ID          = var.github_app_id
+      GITHUB_INSTALLATION_ID = var.github_installation_id
+      FIRESTORE_DATABASE     = "(default)"
+      FIRESTORE_COLLECTION   = var.firestore_collection
+      LOG_LEVEL              = "info"
+    }
+
+    secret_environment_variables {
+      key        = "GITHUB_APP_KEY"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.github_app_key.secret_id
+      version    = "latest"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ----------------------------------------------------------------------------
+# rebalancer — Cloud-Scheduler-triggered every 1 min; drift recovery
+# ----------------------------------------------------------------------------
+
+resource "google_cloudfunctions2_function" "rebalancer" {
+  name     = "${var.prefix}-rebalancer"
+  location = var.gcp_region
+
+  build_config {
+    runtime     = "go122"
+    entry_point = "Handler"
+
+    source {
+      storage_source {
+        bucket = google_storage_bucket.functions.name
+        object = google_storage_bucket_object.function_zip["rebalancer"].name
+      }
+    }
+  }
+
+  service_config {
+    available_memory      = var.function_memory
+    timeout_seconds       = var.function_timeout_seconds
+    max_instance_count    = 1
+    ingress_settings      = "ALLOW_INTERNAL_ONLY"
+    service_account_email = google_service_account.rebalancer.email
+
+    environment_variables = {
+      CLOUD_PROVIDER         = "gcp"
+      GCP_PROJECT            = var.gcp_project
+      GCP_REGION             = var.gcp_region
+      GITHUB_APP_ID          = var.github_app_id
+      GITHUB_INSTALLATION_ID = var.github_installation_id
+      PUBSUB_JOBS_TOPIC      = google_pubsub_topic.jobs.id
+      FIRESTORE_DATABASE     = "(default)"
+      FIRESTORE_COLLECTION   = var.firestore_collection
+      LOG_LEVEL              = "info"
+    }
+
+    secret_environment_variables {
+      key        = "GITHUB_APP_KEY"
+      project_id = var.gcp_project
+      secret     = google_secret_manager_secret.github_app_key.secret_id
+      version    = "latest"
+    }
+  }
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/terraform-gcp/iam.tf
+++ b/infra/terraform-gcp/iam.tf
@@ -1,0 +1,168 @@
+# ============================================================================
+# Service accounts
+# ============================================================================
+
+# 5 function SAs — one per Cloud Run function
+
+resource "google_service_account" "webhook" {
+  account_id   = "${var.prefix}-webhook-sa"
+  display_name = "${var.prefix} webhook function"
+  description  = "Identity for the jit-runners webhook function — publishes to jobs + lifecycle Pub/Sub topics."
+}
+
+resource "google_service_account" "scaleup" {
+  account_id   = "${var.prefix}-scaleup-sa"
+  display_name = "${var.prefix} scaleup function"
+  description  = "Identity for the jit-runners scaleup function — Firestore RW, GCE instance launches, GitHub App key access."
+}
+
+resource "google_service_account" "scaledown" {
+  account_id   = "${var.prefix}-scaledown-sa"
+  display_name = "${var.prefix} scaledown function"
+  description  = "Identity for the jit-runners scaledown function — Firestore RW, GCE instance termination, jobs topic re-enqueue."
+}
+
+resource "google_service_account" "lifecycle" {
+  account_id   = "${var.prefix}-lifecycle-sa"
+  display_name = "${var.prefix} lifecycle function"
+  description  = "Identity for the jit-runners lifecycle function — Firestore RW, GitHub App key access for DeregisterRunner."
+}
+
+resource "google_service_account" "rebalancer" {
+  account_id   = "${var.prefix}-rebalancer-sa"
+  display_name = "${var.prefix} rebalancer function"
+  description  = "Identity for the jit-runners rebalancer function — Firestore reads (ListActiveRepos), jobs topic publishes."
+}
+
+# Runner VM SA — bound to ephemeral GCE instances jit-runners launches
+
+resource "google_service_account" "runner" {
+  account_id   = "${var.prefix}-runner-sa"
+  display_name = "${var.prefix} runner VM identity"
+  description  = "Identity attached to ephemeral runner GCE VMs. logging.logWriter + monitoring.metricWriter + tightly-scoped self-terminate."
+}
+
+# Invoker SAs — Eventarc and Cloud Scheduler use these to invoke functions
+
+resource "google_service_account" "eventarc_invoker" {
+  account_id   = "${var.prefix}-eventarc-invoker-sa"
+  display_name = "${var.prefix} Eventarc invoker"
+  description  = "Eventarc OIDC identity for invoking scaleup + lifecycle Cloud Run functions."
+}
+
+resource "google_service_account" "scheduler_invoker" {
+  account_id   = "${var.prefix}-scheduler-invoker-sa"
+  display_name = "${var.prefix} Cloud Scheduler invoker"
+  description  = "Cloud Scheduler OIDC identity for invoking scaledown + rebalancer Cloud Run functions."
+}
+
+# ============================================================================
+# Project-level role bindings (scaleup + scaledown need broad GCE permissions)
+# ============================================================================
+
+# scaleup: launch GCE instances + impersonate runner SA on the launched VMs
+# Per spec D15, project-level for v1; scope-down deferred.
+
+resource "google_project_iam_member" "scaleup_compute_admin" {
+  project = var.gcp_project
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.scaleup.email}"
+}
+
+resource "google_service_account_iam_member" "scaleup_uses_runner_sa" {
+  service_account_id = google_service_account.runner.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.scaleup.email}"
+}
+
+# scaledown: terminate GCE instances. Same project-level scope as scaleup
+# (the same broad role is needed; scope-down via custom role is a follow-up
+# per spec D15).
+
+resource "google_project_iam_member" "scaledown_compute_admin" {
+  project = var.gcp_project
+  role    = "roles/compute.instanceAdmin.v1"
+  member  = "serviceAccount:${google_service_account.scaledown.email}"
+}
+
+# Function SAs: Datastore (Firestore) read/write
+# scaleup, scaledown, lifecycle, rebalancer all read+write Firestore.
+# webhook does NOT read Firestore (it only publishes to Pub/Sub).
+
+resource "google_project_iam_member" "datastore_user" {
+  for_each = toset([
+    google_service_account.scaleup.email,
+    google_service_account.scaledown.email,
+    google_service_account.lifecycle.email,
+    google_service_account.rebalancer.email,
+  ])
+
+  project = var.gcp_project
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${each.value}"
+}
+
+# Runner VM SA: log + metric writer
+
+resource "google_project_iam_member" "runner_log_writer" {
+  project = var.gcp_project
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.runner.email}"
+}
+
+resource "google_project_iam_member" "runner_metric_writer" {
+  project = var.gcp_project
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.runner.email}"
+}
+
+# ============================================================================
+# Runner self-terminate (blast-radius containment, NOT scope-down per D15)
+#
+# Lets the runner SA delete only instances it can prove are jit-runners
+# instances (label managed-by=jit-runners). Even if the runner SA is
+# compromised, the blast radius is "delete other jit-runner VMs in this
+# project" — bounded.
+# ============================================================================
+
+resource "google_project_iam_custom_role" "runner_self_terminate" {
+  role_id     = "${replace(var.prefix, "-", "_")}_runner_self_terminate"
+  title       = "${var.prefix} runner self-terminate"
+  description = "Permits compute.instances.delete on instances labeled managed-by=jit-runners only."
+  permissions = ["compute.instances.delete"]
+}
+
+resource "google_project_iam_member" "runner_self_terminate" {
+  project = var.gcp_project
+  role    = google_project_iam_custom_role.runner_self_terminate.id
+  member  = "serviceAccount:${google_service_account.runner.email}"
+
+  condition {
+    title       = "self-terminate own instance only"
+    description = "Restricts runner SA to deleting only instances tagged managed-by=jit-runners."
+    expression  = <<-EOT
+      resource.type == "compute.googleapis.com/Instance" &&
+      resource.labels.managed-by == "jit-runners"
+    EOT
+  }
+}
+
+# ============================================================================
+# Pub/Sub service-agent grants
+#
+# Pub/Sub-managed dead-letter delivery uses the project's gcp-sa-pubsub
+# service agent. Without these grants, DLQ delivery silently drops failed
+# messages.
+# ============================================================================
+
+resource "google_pubsub_topic_iam_member" "jobs_dlq_publisher" {
+  topic  = google_pubsub_topic.jobs_dlq.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_pubsub_topic_iam_member" "lifecycle_dlq_publisher" {
+  topic  = google_pubsub_topic.lifecycle_dlq.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}

--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -1,0 +1,68 @@
+# ----------------------------------------------------------------------------
+# Provider config + project lookup
+# ----------------------------------------------------------------------------
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+
+  default_labels = {
+    managed-by = "jit-runners"
+    project    = "jit-runners"
+  }
+}
+
+data "google_project" "current" {
+  project_id = var.gcp_project
+}
+
+# ----------------------------------------------------------------------------
+# Locals
+# ----------------------------------------------------------------------------
+
+locals {
+  function_names = ["webhook", "scaleup", "scaledown", "lifecycle", "rebalancer"]
+}
+
+# ----------------------------------------------------------------------------
+# Random suffix for the function-source bucket (GCS bucket names are global)
+# ----------------------------------------------------------------------------
+
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+# ----------------------------------------------------------------------------
+# Project API enablement (12 APIs)
+#
+# First-time apply must enable these before any resources can be created.
+# Using google_project_service makes the dependency explicit so first-time
+# applies don't fail on disabled APIs. Operators bringing existing projects
+# usually have most of these on already; google_project_service is idempotent.
+# ----------------------------------------------------------------------------
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com",       # cloudfunctions Gen 2 builds via Cloud Build
+    "run.googleapis.com",               # cloudfunctions Gen 2 runs on Cloud Run
+    "eventarc.googleapis.com",
+    "pubsub.googleapis.com",
+    "firestore.googleapis.com",
+    "secretmanager.googleapis.com",
+    "compute.googleapis.com",
+    "cloudscheduler.googleapis.com",
+    "storage.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",    # required for SA token minting
+  ])
+
+  project = var.gcp_project
+  service = each.value
+
+  # Don't disable APIs on `terraform destroy` — other workloads in the project
+  # may rely on them. This is the conservative default for a multi-tenant
+  # project. If the project is single-purpose, operators can flip this in a
+  # post-merge customization fork.
+  disable_on_destroy = false
+}

--- a/infra/terraform-gcp/main.tf
+++ b/infra/terraform-gcp/main.tf
@@ -44,8 +44,8 @@ resource "random_id" "bucket_suffix" {
 resource "google_project_service" "apis" {
   for_each = toset([
     "cloudfunctions.googleapis.com",
-    "cloudbuild.googleapis.com",       # cloudfunctions Gen 2 builds via Cloud Build
-    "run.googleapis.com",               # cloudfunctions Gen 2 runs on Cloud Run
+    "cloudbuild.googleapis.com", # cloudfunctions Gen 2 builds via Cloud Build
+    "run.googleapis.com",        # cloudfunctions Gen 2 runs on Cloud Run
     "eventarc.googleapis.com",
     "pubsub.googleapis.com",
     "firestore.googleapis.com",
@@ -54,7 +54,7 @@ resource "google_project_service" "apis" {
     "cloudscheduler.googleapis.com",
     "storage.googleapis.com",
     "iam.googleapis.com",
-    "iamcredentials.googleapis.com",    # required for SA token minting
+    "iamcredentials.googleapis.com", # required for SA token minting
   ])
 
   project = var.gcp_project

--- a/infra/terraform-gcp/outputs.tf
+++ b/infra/terraform-gcp/outputs.tf
@@ -1,0 +1,62 @@
+# ============================================================================
+# Function URIs
+# ============================================================================
+
+output "webhook_url" {
+  description = "URL to configure as the GitHub App webhook endpoint. Public-facing (ingress=ALLOW_ALL); HMAC-verified in the function code."
+  value       = google_cloudfunctions2_function.webhook.service_config[0].uri
+}
+
+output "scaleup_url" {
+  description = "Internal URL for the scaleup function (Eventarc target). Operators rarely call this directly."
+  value       = google_cloudfunctions2_function.scaleup.service_config[0].uri
+}
+
+output "scaledown_url" {
+  description = "Internal URL for the scaledown function (Cloud Scheduler target)."
+  value       = google_cloudfunctions2_function.scaledown.service_config[0].uri
+}
+
+output "lifecycle_url" {
+  description = "Internal URL for the lifecycle function (Eventarc target)."
+  value       = google_cloudfunctions2_function.lifecycle.service_config[0].uri
+}
+
+output "rebalancer_url" {
+  description = "Internal URL for the rebalancer function (Cloud Scheduler target)."
+  value       = google_cloudfunctions2_function.rebalancer.service_config[0].uri
+}
+
+# ============================================================================
+# Storage / Pub/Sub / Firestore
+# ============================================================================
+
+output "function_source_bucket" {
+  description = "GCS bucket holding versioned function source zips. Operators do not write to this — Terraform fetches from GitHub Releases per D11."
+  value       = google_storage_bucket.functions.name
+}
+
+output "jobs_topic" {
+  description = "Pub/Sub topic for scaleup messages. Use with `gcloud pubsub topics publish` for manual injection during ops debugging."
+  value       = google_pubsub_topic.jobs.id
+}
+
+output "lifecycle_topic" {
+  description = "Pub/Sub topic for lifecycle messages (workflow_job in_progress/completed)."
+  value       = google_pubsub_topic.lifecycle.id
+}
+
+output "jobs_dlq_inspector_subscription" {
+  description = "Pull subscription for inspecting jobs DLQ messages via `gcloud pubsub subscriptions pull`."
+  value       = google_pubsub_subscription.jobs_dlq_inspector.name
+}
+
+output "lifecycle_dlq_inspector_subscription" {
+  description = "Pull subscription for inspecting lifecycle DLQ messages via `gcloud pubsub subscriptions pull`."
+  value       = google_pubsub_subscription.lifecycle_dlq_inspector.name
+}
+
+output "runners_collection" {
+  description = "Firestore collection name for runner state records. Use with `gcloud firestore documents` for ops debugging."
+  value       = var.firestore_collection
+}

--- a/infra/terraform-gcp/pubsub.tf
+++ b/infra/terraform-gcp/pubsub.tf
@@ -1,0 +1,132 @@
+# ============================================================================
+# Topics
+# ============================================================================
+
+resource "google_pubsub_topic" "jobs" {
+  name = "${var.prefix}-jobs"
+}
+
+resource "google_pubsub_topic" "jobs_dlq" {
+  name = "${var.prefix}-jobs-dlq"
+}
+
+resource "google_pubsub_topic" "lifecycle" {
+  name = "${var.prefix}-lifecycle"
+}
+
+resource "google_pubsub_topic" "lifecycle_dlq" {
+  name = "${var.prefix}-lifecycle-dlq"
+}
+
+# ============================================================================
+# Active subscriptions with explicit DLQ + retry policy (D13)
+#
+# Eventarc triggers reference the underlying topics. These subscriptions
+# carry the explicit DLQ + retry policy that mirrors AWS SQS RedrivePolicy.
+# At first apply, verify via `gcloud eventarc triggers describe` that the
+# active delivery actually uses these subs. If Eventarc creates its own
+# managed subs and ignores ours, file a follow-up issue per D13 — operator
+# workaround is to use the inspector subs on the topic for failed-message
+# inspection.
+# ============================================================================
+
+resource "google_pubsub_subscription" "jobs_scaleup" {
+  name                       = "${var.prefix}-jobs-scaleup"
+  topic                      = google_pubsub_topic.jobs.name
+  ack_deadline_seconds       = 60
+  message_retention_duration = "86400s" # 24h
+
+  expiration_policy {
+    ttl = "" # never expires
+  }
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.jobs_dlq.id
+    max_delivery_attempts = 3 # mirrors AWS RedrivePolicy.maxReceiveCount
+  }
+
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+}
+
+resource "google_pubsub_subscription" "lifecycle_lifecycle" {
+  name                       = "${var.prefix}-lifecycle-lifecycle"
+  topic                      = google_pubsub_topic.lifecycle.name
+  ack_deadline_seconds       = 90
+  message_retention_duration = "604800s" # 7 days; mirrors AWS lifecycle queue retention
+
+  expiration_policy {
+    ttl = "" # never expires
+  }
+
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.lifecycle_dlq.id
+    max_delivery_attempts = 5 # mirrors AWS RedrivePolicy.maxReceiveCount
+  }
+
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+}
+
+# ============================================================================
+# DLQ inspector subscriptions
+#
+# Passive subs (no push endpoint) so operators can `gcloud pubsub subscriptions
+# pull` to inspect dead-lettered messages during ops debugging. 14-day retention
+# mirrors AWS DLQ retention.
+# ============================================================================
+
+resource "google_pubsub_subscription" "jobs_dlq_inspector" {
+  name                       = "${var.prefix}-jobs-dlq-inspector"
+  topic                      = google_pubsub_topic.jobs_dlq.name
+  message_retention_duration = "1209600s" # 14 days
+
+  expiration_policy {
+    ttl = ""
+  }
+}
+
+resource "google_pubsub_subscription" "lifecycle_dlq_inspector" {
+  name                       = "${var.prefix}-lifecycle-dlq-inspector"
+  topic                      = google_pubsub_topic.lifecycle_dlq.name
+  message_retention_duration = "1209600s" # 14 days
+
+  expiration_policy {
+    ttl = ""
+  }
+}
+
+# ============================================================================
+# Topic-level publisher grants
+#
+# webhook publishes to BOTH topics; rebalancer + scaledown publish to jobs
+# only.
+# ============================================================================
+
+resource "google_pubsub_topic_iam_member" "webhook_jobs_publisher" {
+  topic  = google_pubsub_topic.jobs.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.webhook.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "webhook_lifecycle_publisher" {
+  topic  = google_pubsub_topic.lifecycle.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.webhook.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "rebalancer_jobs_publisher" {
+  topic  = google_pubsub_topic.jobs.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.rebalancer.email}"
+}
+
+resource "google_pubsub_topic_iam_member" "scaledown_jobs_publisher" {
+  topic  = google_pubsub_topic.jobs.id
+  role   = "roles/pubsub.publisher"
+  member = "serviceAccount:${google_service_account.scaledown.email}"
+}

--- a/infra/terraform-gcp/scheduler.tf
+++ b/infra/terraform-gcp/scheduler.tf
@@ -1,0 +1,65 @@
+# ============================================================================
+# Cloud Scheduler jobs
+# ============================================================================
+
+# Scheduler-invoker SA needs roles/run.invoker on each target function.
+
+resource "google_cloud_run_v2_service_iam_member" "scheduler_invokes_scaledown" {
+  project  = var.gcp_project
+  location = var.gcp_region
+  name     = google_cloudfunctions2_function.scaledown.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "scheduler_invokes_rebalancer" {
+  project  = var.gcp_project
+  location = var.gcp_region
+  name     = google_cloudfunctions2_function.rebalancer.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.scheduler_invoker.email}"
+}
+
+# scaledown: every 5 minutes (mirrors AWS EventBridge rate(5 minutes))
+
+resource "google_cloud_scheduler_job" "scaledown" {
+  name        = "${var.prefix}-scaledown"
+  description = "Triggers the jit-runners scaledown function every 5 minutes."
+  schedule    = "*/5 * * * *"
+  time_zone   = "Etc/UTC"
+  region      = var.gcp_region
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloudfunctions2_function.scaledown.service_config[0].uri
+
+    oidc_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+      audience              = google_cloudfunctions2_function.scaledown.service_config[0].uri
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_service_iam_member.scheduler_invokes_scaledown]
+}
+
+# rebalancer: every minute (mirrors AWS EventBridge rate(1 minute))
+
+resource "google_cloud_scheduler_job" "rebalancer" {
+  name        = "${var.prefix}-rebalancer"
+  description = "Triggers the jit-runners rebalancer function every minute."
+  schedule    = "* * * * *"
+  time_zone   = "Etc/UTC"
+  region      = var.gcp_region
+
+  http_target {
+    http_method = "POST"
+    uri         = google_cloudfunctions2_function.rebalancer.service_config[0].uri
+
+    oidc_token {
+      service_account_email = google_service_account.scheduler_invoker.email
+      audience              = google_cloudfunctions2_function.rebalancer.service_config[0].uri
+    }
+  }
+
+  depends_on = [google_cloud_run_v2_service_iam_member.scheduler_invokes_rebalancer]
+}

--- a/infra/terraform-gcp/secrets.tf
+++ b/infra/terraform-gcp/secrets.tf
@@ -1,0 +1,63 @@
+# ============================================================================
+# Secret Manager secrets
+# ============================================================================
+
+resource "google_secret_manager_secret" "webhook_secret" {
+  secret_id = "${var.prefix}-webhook-secret"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "webhook_secret" {
+  secret      = google_secret_manager_secret.webhook_secret.id
+  secret_data = var.webhook_secret_value
+}
+
+resource "google_secret_manager_secret" "github_app_key" {
+  secret_id = "${var.prefix}-github-app-key"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "github_app_key" {
+  secret      = google_secret_manager_secret.github_app_key.id
+  secret_data = var.github_app_private_key
+}
+
+# ============================================================================
+# Secret access bindings
+#
+# Each function SA gets secretAccessor on the secrets it actually consumes
+# at runtime — least privilege per-secret.
+# ============================================================================
+
+# Webhook secret: only webhook function reads it (HMAC verification).
+
+resource "google_secret_manager_secret_iam_member" "webhook_secret_webhook" {
+  secret_id = google_secret_manager_secret.webhook_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.webhook.email}"
+}
+
+# GitHub App private key: webhook (for installation token minting if it
+# ever needs to call GitHub), scaleup (generate-jitconfig), scaledown
+# (DeregisterRunner), lifecycle (DeregisterRunner), rebalancer
+# (ListQueuedWorkflowJobs).
+
+resource "google_secret_manager_secret_iam_member" "github_app_key_readers" {
+  for_each = toset([
+    google_service_account.webhook.email,
+    google_service_account.scaleup.email,
+    google_service_account.scaledown.email,
+    google_service_account.lifecycle.email,
+    google_service_account.rebalancer.email,
+  ])
+
+  secret_id = google_secret_manager_secret.github_app_key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${each.value}"
+}

--- a/infra/terraform-gcp/storage.tf
+++ b/infra/terraform-gcp/storage.tf
@@ -19,7 +19,7 @@ resource "google_storage_bucket" "functions" {
   # Lets operators roll back to a previous release_tag for the retention window.
   lifecycle_rule {
     condition { age = 90 }
-    action    { type = "Delete" }
+    action { type = "Delete" }
   }
 }
 

--- a/infra/terraform-gcp/storage.tf
+++ b/infra/terraform-gcp/storage.tf
@@ -1,0 +1,57 @@
+# ----------------------------------------------------------------------------
+# Function source bucket
+#
+# Cloud Functions Gen 2 requires the build source in GCS or Cloud Source
+# Repositories — there is no native "fetch from URL" option. We use GCS.
+# Operators never touch this bucket directly: the data.http chain below
+# downloads from GitHub Releases and uploads here automatically.
+# ----------------------------------------------------------------------------
+
+resource "google_storage_bucket" "functions" {
+  name                        = "${var.prefix}-functions-${random_id.bucket_suffix.hex}"
+  location                    = var.gcp_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+
+  versioning { enabled = true }
+
+  # Retain old function source zips for 90 days, then auto-clean.
+  # Lets operators roll back to a previous release_tag for the retention window.
+  lifecycle_rule {
+    condition { age = 90 }
+    action    { type = "Delete" }
+  }
+}
+
+# ----------------------------------------------------------------------------
+# GitHub Release fetch chain (D11)
+#
+# Per-function 3-step chain:
+#   1. data.http downloads the zip body, base64-encoded.
+#   2. local_file writes the base64-decoded bytes to disk under .cache/.
+#   3. google_storage_bucket_object uploads the file to the bucket.
+#
+# All three resources use for_each over local.function_names so the chain
+# scales to all 5 functions with no duplication.
+# ----------------------------------------------------------------------------
+
+# 1. Fetch each zip from the GitHub Release as base64-encoded body.
+data "http" "function_zips" {
+  for_each = toset(local.function_names)
+  url      = "https://github.com/devopsfactory-io/jit-runners/releases/download/${var.release_tag}/${each.key}.zip"
+}
+
+# 2. Land each base64-decoded body on local disk (Terraform-managed cache).
+resource "local_file" "function_zips" {
+  for_each       = toset(local.function_names)
+  filename       = "${path.module}/.cache/${var.release_tag}/${each.key}.zip"
+  content_base64 = data.http.function_zips[each.key].response_body_base64
+}
+
+# 3. Upload to GCS so Cloud Functions Gen 2 can build from it.
+resource "google_storage_bucket_object" "function_zip" {
+  for_each = toset(local.function_names)
+  name     = "${var.release_tag}/${each.key}.zip"
+  bucket   = google_storage_bucket.functions.name
+  source   = local_file.function_zips[each.key].filename
+}

--- a/infra/terraform-gcp/terraform.tfvars.example
+++ b/infra/terraform-gcp/terraform.tfvars.example
@@ -1,0 +1,82 @@
+# ============================================================================
+# jit-runners GCP Terraform module — example tfvars
+#
+# Copy to terraform.tfvars (gitignored) and fill in. Run:
+#   tofu init && tofu plan && tofu apply
+#
+# First apply notes:
+#   - First apply enables 12 GCP APIs (~1-2 min). If any individual API
+#     enablement fails, re-run apply — google_project_service is idempotent.
+#   - First apply also triggers Cloud Build to build container images for
+#     all 5 Cloud Run functions (~5-10 min total). Subsequent applies with
+#     the same release_tag are fast (no rebuilds).
+#   - State will grow ~50MB per release_tag bump (5 zips × ~10MB base64-
+#     encoded in state). Use a GCS remote backend (see versions.tf comment).
+# ============================================================================
+
+# --- Identity ---
+
+gcp_project = "my-jit-runners-project"
+gcp_region  = "us-central1"
+prefix      = "jit-runners"  # All resources named ${prefix}-<role>
+
+# --- Release pinning (D11) ---
+
+# The GitHub release tag to deploy. Module fetches the 5 function zips from
+#   https://github.com/devopsfactory-io/jit-runners/releases/download/<tag>/<func>.zip
+# automatically — no operator-side upload step. Bump and re-apply to deploy
+# a new release.
+release_tag = "v1.0.0-rc.5"
+
+# --- Firestore (D12) ---
+
+# Set true if your project has NO Firestore database yet. Set false if you
+# already have one (Firestore Native is a project-level singleton; trying
+# to create a second errors).
+create_firestore_database = false
+
+# --- Runner image ---
+
+# The maintainer publishes a public GCE image with each tagged release. To
+# use it, set runner_image to:
+#   "projects/<maintainer-project>/global/images/jit-runner-<version>-..."
+#
+# Or build your own private image via:
+#   make image.build-test GCP_PROJECT=my-jit-runners-project
+# and reference its image URI here.
+runner_image  = "projects/devopsfactory-io-jit-runners/global/images/jit-runner-v1-runner2-332-0-1700000000"
+runner_subnet = "projects/my-jit-runners-project/regions/us-central1/subnetworks/default"
+# runner_network = "default"      # uncomment to override default
+# runner_zone    = "us-central1-a" # uncomment to override default
+
+# --- GitHub App credentials ---
+
+github_app_id          = "123456"  # Your GitHub App's numeric ID
+github_installation_id = "789012"  # Installation ID from your GitHub App settings
+
+# Webhook secret (HMAC) — written to Secret Manager. Generate via:
+#   openssl rand -hex 32
+# and configure the same value in your GitHub App's webhook secret field.
+webhook_secret_value = "REDACTED-32-byte-hex-string"
+
+# GitHub App private key (PEM body) — written to Secret Manager. Download from
+# your GitHub App's settings page, then paste here.
+github_app_private_key = <<-EOT
+-----BEGIN RSA PRIVATE KEY-----
+... (paste full PEM body) ...
+-----END RSA PRIVATE KEY-----
+EOT
+
+# --- Operational thresholds (defaults usually fine) ---
+
+# label_mappings          = "[]"   # JSON: [{"label":"large","machine_type":"n2-standard-8"}, ...]
+# max_runner_age_minutes  = 360    # Force-terminate runners older than this
+# stale_threshold_minutes = 10     # Re-enqueue stuck pending runners after this
+# max_re_enqueue_attempts = 3      # Stuck pending → terminal after this many re-enqueues
+
+# --- Function scaling knobs (defaults usually fine) ---
+
+# function_memory          = "256M"
+# function_timeout_seconds = 60
+# max_instance_count       = 10  # Per-function ceiling for webhook + scaleup + lifecycle
+                                 # (scaledown + rebalancer are pinned to 1)

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -14,7 +14,7 @@ variable "gcp_region" {
 }
 
 variable "prefix" {
-  description = "Resource name prefix. All resources are named ${prefix}-<role> (e.g. jit-runners-webhook, jit-runners-jobs)."
+  description = "Resource name prefix. All resources are named <prefix>-<role> (e.g. jit-runners-webhook, jit-runners-jobs)."
   type        = string
   default     = "jit-runners"
 }

--- a/infra/terraform-gcp/variables.tf
+++ b/infra/terraform-gcp/variables.tf
@@ -1,0 +1,147 @@
+# ----------------------------------------------------------------------------
+# Identity
+# ----------------------------------------------------------------------------
+
+variable "gcp_project" {
+  description = "GCP project ID where jit-runners deploys."
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "Default GCP region for regional resources (Cloud Run functions, Cloud Scheduler, GCS bucket location)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "prefix" {
+  description = "Resource name prefix. All resources are named ${prefix}-<role> (e.g. jit-runners-webhook, jit-runners-jobs)."
+  type        = string
+  default     = "jit-runners"
+}
+
+# ----------------------------------------------------------------------------
+# Release pinning (D11)
+# ----------------------------------------------------------------------------
+
+variable "release_tag" {
+  description = "jit-runners GitHub release tag whose function zips this deploy uses (e.g. \"v1.0.0-rc.5\"). Bumping this and re-applying re-deploys all five Cloud Run functions."
+  type        = string
+}
+
+# ----------------------------------------------------------------------------
+# Firestore (D12 — feature flag for greenfield bootstrap)
+# ----------------------------------------------------------------------------
+
+variable "create_firestore_database" {
+  description = "Whether to create the (default) Firestore Native database. Set true for fresh GCP projects with no Firestore yet; set false for projects that already have one (most common case)."
+  type        = bool
+  default     = false
+}
+
+variable "firestore_collection" {
+  description = "Firestore collection name for jit-runners runner records."
+  type        = string
+  default     = "runners"
+}
+
+# ----------------------------------------------------------------------------
+# Runner image (built by D-Packer; referenced here)
+# ----------------------------------------------------------------------------
+
+variable "runner_image" {
+  description = "Full GCE image URI to use as the runner VM base image (e.g. projects/<maintainer-project>/global/images/jit-runner-v1-runner2.332.0-1700000000)."
+  type        = string
+}
+
+variable "runner_network" {
+  description = "VPC network name or full path for runner VMs."
+  type        = string
+  default     = "default"
+}
+
+variable "runner_subnet" {
+  description = "VPC subnetwork full path for runner VMs (e.g. projects/<p>/regions/<r>/subnetworks/<s>)."
+  type        = string
+}
+
+variable "runner_zone" {
+  description = "GCE zone where runner VMs launch."
+  type        = string
+  default     = "us-central1-a"
+}
+
+# ----------------------------------------------------------------------------
+# GitHub App credentials
+# ----------------------------------------------------------------------------
+
+variable "github_app_id" {
+  description = "GitHub App ID (numeric), as a string."
+  type        = string
+}
+
+variable "github_installation_id" {
+  description = "GitHub App installation ID (numeric), as a string."
+  type        = string
+}
+
+variable "webhook_secret_value" {
+  description = "GitHub App webhook secret (HMAC) — written to Secret Manager."
+  type        = string
+  sensitive   = true
+}
+
+variable "github_app_private_key" {
+  description = "GitHub App private key in PEM format — written to Secret Manager."
+  type        = string
+  sensitive   = true
+}
+
+# ----------------------------------------------------------------------------
+# Cloud Run function scaling knobs
+# ----------------------------------------------------------------------------
+
+variable "function_memory" {
+  description = "Memory allocation for Cloud Run functions (e.g. \"256M\")."
+  type        = string
+  default     = "256M"
+}
+
+variable "function_timeout_seconds" {
+  description = "Timeout in seconds for Cloud Run function invocations."
+  type        = number
+  default     = 60
+}
+
+variable "max_instance_count" {
+  description = "Maximum concurrent instances for scaling-flexible functions (webhook, scaleup, lifecycle). scaledown and rebalancer are always pinned to 1."
+  type        = number
+  default     = 10
+}
+
+# ----------------------------------------------------------------------------
+# Operational thresholds (parity with AWS Terraform module)
+# ----------------------------------------------------------------------------
+
+variable "label_mappings" {
+  description = "JSON-encoded array of label-to-machine-type mappings. Empty array (\"[]\") means use default machine type for all labels."
+  type        = string
+  default     = "[]"
+}
+
+variable "max_runner_age_minutes" {
+  description = "Force-terminate runner VMs older than this. Mirrors AWS MaxRunnerAgeMinutes."
+  type        = number
+  default     = 360
+}
+
+variable "stale_threshold_minutes" {
+  description = "Pending runners older than this are considered stuck and re-enqueued. Mirrors AWS StaleThresholdMinutes."
+  type        = number
+  default     = 10
+}
+
+variable "max_re_enqueue_attempts" {
+  description = "Stuck pending runners are re-enqueued up to this many times before going terminal. Mirrors AWS MaxReEnqueueAttempts."
+  type        = number
+  default     = 3
+}

--- a/infra/terraform-gcp/versions.tf
+++ b/infra/terraform-gcp/versions.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.30.0"
+    }
+
+    # http >= 3.4 required for response_body_base64 (D11 — binary download).
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.4.0"
+    }
+
+    # local >= 2.5 required for content_base64 (D11 — binary writeback).
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.5.0"
+    }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.6.0"
+    }
+  }
+
+  # Configure your backend here.
+  # backend "gcs" {
+  #   bucket = "your-terraform-state-bucket"
+  #   prefix = "jit-runners"
+  # }
+}


### PR DESCRIPTION
## Summary

Second half of Phase D per spec D9. Adds the \`infra/terraform-gcp/\` module — a self-sufficient OpenTofu/Terraform module that deploys jit-runners on GCP. Operators populate \`terraform.tfvars\`, run \`tofu apply\`, and have working jit-runners infrastructure.

### Changes

- **\`infra/terraform-gcp/\`** (new module, 12 .tf files + tfvars.example): versions, variables (~22), main (provider + 12 API enablement + bucket suffix), storage (bucket + D11 fetch chain), iam (8 SAs + custom self-terminate), secrets (2 Secret Manager + IAM), firestore (D12 conditional + TTL), pubsub (4 topics + 4 subs with explicit DLQ + retry per D13), eventarc (2 triggers per D3), functions (5 google_cloudfunctions2_function per D10), scheduler (2 jobs), outputs, terraform.tfvars.example.
- **GitHub Releases as source of truth (D11)**: function zips are fetched declaratively via \`data.http\` → \`local_file\` → \`google_storage_bucket_object\`. No \`null_resource\`. Operator UX: bump \`var.release_tag\`, \`tofu apply\`.
- **No AWS-side changes**: \`infra/terraform/\` is unchanged; \`infra/terraform-gcp/\` is a parallel module. Verified zero diff.
- **D14 footnote**: image-build CI identity is NOT in this module (it lives out-of-band in the maintainer's personal GCP project; D-Packer's workflow references it via repo secrets).

### Refs

- Spec: zettelkasten \`Projects/jit-runners/specs/2026-05-01-gcp-support-and-cloud-abstraction-design.md\` (Phase D decision log D9-D15 at commit \`7783f57\`).
- Plan: zettelkasten \`Projects/jit-runners/plans/2026-05-02-gcp-phase-D-terraform.md\`.
- Builds on the Packer half: \`Projects/jit-runners/plans/2026-05-02-gcp-phase-D-packer.md\` (PR #69, merged).
- Closes the D side of #45 (Phase D). E (docs) and F (live verification) follow.

## Test plan

- [x] \`tofu init -backend=false\` resolves all 5 providers.
- [x] \`tofu validate\` clean on \`infra/terraform-gcp/\` (final state).
- [x] \`tofu fmt -check -recursive infra/terraform-gcp\` clean.
- [x] \`infra/terraform/\` (AWS) unchanged — zero-line diff against \`origin/feat/gcp-support\`.
- [x] All grep guards pass: 12 .tf files, 5 functions, 4 topics, 4 subs, 2 triggers, 2 schedulers, 8 SAs, 2 secrets, conditional Firestore, D11 fetch chain present (1 each of data.http / local_file / google_storage_bucket_object with for_each).
- [x] All 15 commits DCO-signed.
- [ ] After merge: maintainer runs first \`tofu apply\` against a test GCP project. Phase F covers cross-cloud smoke verification.

## D13 verification step (post-merge)

After first \`tofu apply\`, run:

\`\`\`bash
gcloud eventarc triggers describe \${prefix}-scaleup --location=<region> --format='value(transport.pubsub.subscription)'
gcloud eventarc triggers describe \${prefix}-lifecycle --location=<region> --format='value(transport.pubsub.subscription)'
\`\`\`

Expected: each trigger's \`transport.pubsub.subscription\` matches the explicit subscription this module declared (\`\${prefix}-jobs-scaleup\` / \`\${prefix}-lifecycle-lifecycle\`). If Eventarc auto-created its own subscription and ignored ours, file a follow-up issue per D13 — operator workaround is to use the inspector subscriptions on the topics for failed-message inspection until upstream Eventarc behavior changes or we adopt the bare-push pattern.

## Out of scope (still)

- Cross-cloud smoke verification — Phase F.
- Custom \`compute.instanceAdmin.v1\` scope-down — D15 follow-up.
- Composite Firestore indexes — D8 follow-up (only needed if runners collection grows past ~10k docs).
- Documentation rewrite (README, getting-started, troubleshooting) — Phase E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)