### PR TITLE
fix: terminate EC2 on lifecycle completed + scaledown orphan sweep (#74)

### DIFF
--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -92,9 +92,18 @@ Resources:
       AttributeDefinitions:
         - AttributeName: runner_id
           AttributeType: S
+        - AttributeName: instance_id
+          AttributeType: S
       KeySchema:
         - AttributeName: runner_id
           KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: instance_id-index
+          KeySchema:
+            - AttributeName: instance_id
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true

--- a/infra/terraform/dynamodb.tf
+++ b/infra/terraform/dynamodb.tf
@@ -8,6 +8,17 @@ resource "aws_dynamodb_table" "runners" {
     type = "S"
   }
 
+  attribute {
+    name = "instance_id"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "instance_id-index"
+    hash_key        = "instance_id"
+    projection_type = "ALL"
+  }
+
   ttl {
     attribute_name = "ttl"
     enabled        = true

--- a/lambda/cmd/lifecycle/main.go
+++ b/lambda/cmd/lifecycle/main.go
@@ -77,7 +77,7 @@ func handler(ctx context.Context, ev events.SQSEvent) error {
 		return fmt.Errorf("github client: %w", err)
 	}
 
-	h := lifecycle.New(bundleRef.State, ghClient, log.Default())
+	h := lifecycle.New(bundleRef.State, ghClient, bundleRef.Compute, log.Default())
 
 	for _, rec := range ev.Records {
 		if err := h.HandleSQS(ctx, []byte(rec.Body)); err != nil {
@@ -113,7 +113,7 @@ func gcpHandler(ctx context.Context, e cloudevents.Event) error {
 		return fmt.Errorf("decode cloudevent: %w", err)
 	}
 
-	h := lifecycle.New(bundleRef.State, ghClient, log.Default())
+	h := lifecycle.New(bundleRef.State, ghClient, bundleRef.Compute, log.Default())
 	return h.HandleSQS(ctx, body)
 }
 

--- a/lambda/cmd/lifecycle/main_integration_test.go
+++ b/lambda/cmd/lifecycle/main_integration_test.go
@@ -5,7 +5,9 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/lifecycle"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
@@ -28,8 +30,20 @@ func (f *fakeGitHub) DeregisterRunner(_ context.Context, repo string, runnerID i
 	return f.err
 }
 
+// fakeLauncher satisfies compute.Launcher; the integration tests don't
+// exercise compute paths, so all methods are inert.
+type fakeLauncher struct{}
+
+func (fakeLauncher) Launch(_ context.Context, _ compute.LaunchSpec) (compute.Instance, error) {
+	return compute.Instance{}, nil
+}
+func (fakeLauncher) Terminate(_ context.Context, _ []string) error { return nil }
+func (fakeLauncher) ListStale(_ context.Context, _ time.Duration) ([]compute.Instance, error) {
+	return nil, nil
+}
+
 func newHandler(store state.RunnerStore, gh *fakeGitHub) *lifecycle.Handler {
-	return lifecycle.New(store, gh, log.New(os.Stderr, "test ", 0))
+	return lifecycle.New(store, gh, fakeLauncher{}, log.New(os.Stderr, "test ", 0))
 }
 
 func TestLifecycle_InProgressThenCompleted_FollowsRunnerID(t *testing.T) {

--- a/lambda/cmd/scaledown/main.go
+++ b/lambda/cmd/scaledown/main.go
@@ -73,16 +73,17 @@ func handler(ctx context.Context) error {
 	staleMinutes := envInt("STALE_THRESHOLD_MINUTES", 10)
 	maxAgeMinutes := envInt("MAX_RUNNER_AGE_MINUTES", 360)
 	maxReEnqueueAttempts := envInt("MAX_RE_ENQUEUE_ATTEMPTS", 3)
+	orphanGraceMinutes := envInt("ORPHAN_GRACE_MINUTES", 5)
 
 	cleaner := runner.NewCleaner(bundleRef.State, bundleRef.Compute, ghClient, bundleRef.JobsPublisher,
-		staleMinutes, maxAgeMinutes, maxReEnqueueAttempts)
+		staleMinutes, maxAgeMinutes, maxReEnqueueAttempts, orphanGraceMinutes)
 	result, err := cleaner.Run(ctx)
 	if err != nil {
 		return fmt.Errorf("cleanup: %w", err)
 	}
 
-	log.Printf("cleanup complete: stale=%d orphans=%d errors=%d", //nolint:gosec // G706: counters are internal cleanup-result fields from runner.Cleaner — not user input
-		result.Stale, result.Orphans, result.Errors)
+	log.Printf("cleanup complete: stale=%d orphans=%d ec2_orphans=%d errors=%d", //nolint:gosec // G706: counters are internal cleanup-result fields from runner.Cleaner — not user input
+		result.Stale, result.Orphans, result.EC2Orphans, result.Errors)
 	return nil
 }
 

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -200,21 +200,36 @@ func processRecord(ctx context.Context, cfg *appconfig.Config, b *provider.Bundl
 	// Launch succeeded — bind the instance ID and bump LastAttemptAt on the
 	// pending record. The record stays in StatusPending; the runner agent
 	// on the instance will flip it to running via the lifecycle pipeline.
-	now := time.Now()
-	if err := b.State.Update(ctx, pending.ID, state.RunnerUpdate{
-		InstanceID:    &inst.ID,
-		LastAttemptAt: &now,
-	}); err != nil {
-		// The instance is launched and the runner is registered — log and
-		// continue so the message is ack'd. Scaledown will reconcile if
-		// anything goes wrong from here.
-		log.Printf("failed to update runner record with instance %s for runner=%d job=%d: %v",
-			inst.ID, jitCfg.Runner.ID, msg.JobID, err)
+	if err := bindLaunchedInstance(ctx, b, pending.ID, inst.ID, jitCfg.Runner.ID, msg.JobID); err != nil {
+		return err
 	}
 
 	log.Printf("launched instance %s for runner=%d job=%d (%s)",
 		inst.ID, jitCfg.Runner.ID, msg.JobID, msg.RepositoryFull)
 	return nil
+}
+
+// bindLaunchedInstance writes the freshly-launched instance ID onto the
+// pending DDB row. On Update failure it best-effort terminates the EC2
+// instance and returns the wrapped error so SQS redrives — the next
+// attempt launches a fresh instance with a fresh DDB write. Without the
+// defensive Terminate the row would have no InstanceID, leaving an
+// orphan that survives until MaxRunnerAgeMinutes (issue #74 design D1.3).
+func bindLaunchedInstance(ctx context.Context, b *provider.Bundle, recordID, instanceID string, ghRunnerID, jobID int64) error {
+	now := time.Now()
+	err := b.State.Update(ctx, recordID, state.RunnerUpdate{
+		InstanceID:    &instanceID,
+		LastAttemptAt: &now,
+	})
+	if err == nil {
+		return nil
+	}
+	log.Printf("scaleup: update record after launch failed; terminating orphan instance %s for runner=%d job=%d: %v",
+		instanceID, ghRunnerID, jobID, err)
+	if termErr := b.Compute.Terminate(ctx, []string{instanceID}); termErr != nil {
+		log.Printf("scaleup: terminate orphan instance %s failed: %v", instanceID, termErr)
+	}
+	return fmt.Errorf("update runner record after launch: %w", err)
 }
 
 // writePendingRecord persists pending as the pre-launch state. Always a

--- a/lambda/cmd/scaleup/main_integration_test.go
+++ b/lambda/cmd/scaleup/main_integration_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"reflect"
 	"regexp"
 	"testing"
 	"time"
@@ -22,8 +23,10 @@ import (
 
 // fakeLauncher is a minimal compute.Launcher for tests.
 type fakeLauncher struct {
-	launchErr error
-	launches  []compute.LaunchSpec
+	launchErr    error
+	launches     []compute.LaunchSpec
+	terminateErr error
+	terminated   [][]string
 }
 
 func (f *fakeLauncher) Launch(_ context.Context, spec compute.LaunchSpec) (compute.Instance, error) {
@@ -34,10 +37,26 @@ func (f *fakeLauncher) Launch(_ context.Context, spec compute.LaunchSpec) (compu
 	return compute.Instance{ID: "i-test123"}, nil
 }
 
-func (f *fakeLauncher) Terminate(_ context.Context, _ []string) error { return nil }
+func (f *fakeLauncher) Terminate(_ context.Context, ids []string) error {
+	f.terminated = append(f.terminated, ids)
+	return f.terminateErr
+}
 
 func (f *fakeLauncher) ListStale(_ context.Context, _ time.Duration) ([]compute.Instance, error) {
 	return nil, nil
+}
+
+// errorOnUpdateStore wraps a real RunnerStore and forces Update to error.
+// Used to drive the post-Launch + Update-failure code path in T5.
+type errorOnUpdateStore struct {
+	state.RunnerStore
+	updateErr error
+	updates   []string // record IDs we tried to update
+}
+
+func (s *errorOnUpdateStore) Update(_ context.Context, id string, _ state.RunnerUpdate) error {
+	s.updates = append(s.updates, id)
+	return s.updateErr
 }
 
 // TestProcessRecord_ParseFailureIsNoOp verifies that malformed SQS bodies
@@ -221,5 +240,98 @@ func TestShouldLaunch(t *testing.T) {
 				t.Errorf("shouldLaunch = %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestBindLaunchedInstance_TerminatesOnUpdateFailure pins the issue #74
+// design D1.3 contract for the post-Launch + Update-failure path: when
+// Compute.Launch has succeeded but State.Update fails, the helper must
+// (1) call Compute.Terminate with the launched instance ID so the EC2
+// is reclaimed instead of leaking as a no-DDB-row orphan, and (2) return
+// the wrapped Update error so SQS redrives. The next attempt launches a
+// fresh instance with a fresh DDB write.
+func TestBindLaunchedInstance_TerminatesOnUpdateFailure(t *testing.T) {
+	updateErr := errors.New("ddb throttled")
+	store := &errorOnUpdateStore{
+		RunnerStore: memstore.New(),
+		updateErr:   updateErr,
+	}
+	launcher := &fakeLauncher{}
+	b := &provider.Bundle{
+		State:   store,
+		Compute: launcher,
+	}
+
+	const recordID = "999"
+	const instanceID = "i-test123"
+
+	err := bindLaunchedInstance(context.Background(), b, recordID, instanceID, 999, 4567)
+
+	if err == nil {
+		t.Fatal("expected error from bindLaunchedInstance when Update fails")
+	}
+	if !errors.Is(err, updateErr) {
+		t.Errorf("err = %v, want wraps %v", err, updateErr)
+	}
+	if len(launcher.terminated) != 1 {
+		t.Fatalf("expected 1 Terminate call after Update failure, got %d",
+			len(launcher.terminated))
+	}
+	if got, want := launcher.terminated[0], []string{instanceID}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Terminate ids = %v, want %v", got, want)
+	}
+	if len(store.updates) != 1 || store.updates[0] != recordID {
+		t.Errorf("Update calls = %v, want [%q]", store.updates, recordID)
+	}
+}
+
+// TestBindLaunchedInstance_HappyPath verifies the no-error path is a
+// pass-through: no Terminate call, no error returned.
+func TestBindLaunchedInstance_HappyPath(t *testing.T) {
+	launcher := &fakeLauncher{}
+	b := &provider.Bundle{
+		State:   memstore.New(),
+		Compute: launcher,
+	}
+
+	// Seed a pending row so memstore.Update has something to mutate.
+	pending := runner.New("owner/repo", 999, "", 4567, 8910, []string{"self-hosted", "large"})
+	if err := b.State.Put(context.Background(), pending); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	if err := bindLaunchedInstance(context.Background(), b, pending.ID, "i-test123", 999, 4567); err != nil {
+		t.Fatalf("bindLaunchedInstance happy path: %v", err)
+	}
+	if len(launcher.terminated) != 0 {
+		t.Errorf("happy path must not Terminate; got %d calls", len(launcher.terminated))
+	}
+}
+
+// TestBindLaunchedInstance_TerminateErrorStillReturnsUpdateError verifies
+// that even when the defensive Terminate also errors, bindLaunchedInstance
+// still returns the wrapped Update error (Terminate is best-effort and
+// surfaces only via log).
+func TestBindLaunchedInstance_TerminateErrorStillReturnsUpdateError(t *testing.T) {
+	updateErr := errors.New("ddb throttled")
+	store := &errorOnUpdateStore{
+		RunnerStore: memstore.New(),
+		updateErr:   updateErr,
+	}
+	launcher := &fakeLauncher{terminateErr: errors.New("ec2 throttled")}
+	b := &provider.Bundle{
+		State:   store,
+		Compute: launcher,
+	}
+
+	err := bindLaunchedInstance(context.Background(), b, "999", "i-test123", 999, 4567)
+	if err == nil {
+		t.Fatal("expected error even when Terminate also fails")
+	}
+	if !errors.Is(err, updateErr) {
+		t.Errorf("err = %v, want wraps Update err %v (Terminate err must not shadow it)", err, updateErr)
+	}
+	if len(launcher.terminated) != 1 {
+		t.Errorf("expected Terminate to still be attempted; got %d calls", len(launcher.terminated))
 	}
 }

--- a/lambda/internal/aws/dynamo/store.go
+++ b/lambda/internal/aws/dynamo/store.go
@@ -23,6 +23,7 @@ type API interface {
 	GetItem(ctx context.Context, input *dynamodb.GetItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
 	UpdateItem(ctx context.Context, input *dynamodb.UpdateItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
 	Scan(ctx context.Context, input *dynamodb.ScanInput, opts ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	Query(ctx context.Context, input *dynamodb.QueryInput, opts ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
 	DeleteItem(ctx context.Context, input *dynamodb.DeleteItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error)
 }
 
@@ -169,6 +170,35 @@ func (s *Store) Get(ctx context.Context, id string) (state.Runner, error) {
 	}
 	var rec dbRecord
 	if err := attributevalue.UnmarshalMap(out.Item, &rec); err != nil {
+		return state.Runner{}, fmt.Errorf("unmarshal runner record: %w", err)
+	}
+	return fromDB(rec), nil
+}
+
+// GetByInstanceID queries the instance_id-index GSI to look up a runner
+// by its cloud instance ID. Returns state.ErrNotFound if no row matches.
+// Used by the scaledown orphan sweep (issue #74).
+func (s *Store) GetByInstanceID(ctx context.Context, instanceID string) (state.Runner, error) {
+	if instanceID == "" {
+		return state.Runner{}, state.ErrNotFound
+	}
+	out, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.tableName),
+		IndexName:              aws.String("instance_id-index"),
+		KeyConditionExpression: aws.String("instance_id = :iid"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":iid": &types.AttributeValueMemberS{Value: instanceID},
+		},
+		Limit: aws.Int32(1),
+	})
+	if err != nil {
+		return state.Runner{}, fmt.Errorf("query instance_id-index: %w", err)
+	}
+	if len(out.Items) == 0 {
+		return state.Runner{}, state.ErrNotFound
+	}
+	var rec dbRecord
+	if err := attributevalue.UnmarshalMap(out.Items[0], &rec); err != nil {
 		return state.Runner{}, fmt.Errorf("unmarshal runner record: %w", err)
 	}
 	return fromDB(rec), nil

--- a/lambda/internal/aws/dynamo/store_test.go
+++ b/lambda/internal/aws/dynamo/store_test.go
@@ -19,10 +19,12 @@ type mockDDB struct {
 	putInput    *dynamodb.PutItemInput
 	getInput    *dynamodb.GetItemInput
 	scanInput   *dynamodb.ScanInput
+	queryInput  *dynamodb.QueryInput
 	updateInput *dynamodb.UpdateItemInput
 	deleteInput *dynamodb.DeleteItemInput
 	getOut      *dynamodb.GetItemOutput
 	scanOut     *dynamodb.ScanOutput
+	queryOut    *dynamodb.QueryOutput
 	err         error
 	items       map[string]map[string]types.AttributeValue
 }
@@ -76,6 +78,14 @@ func (m *mockDDB) Scan(_ context.Context, in *dynamodb.ScanInput, _ ...func(*dyn
 		return m.scanOut, m.err
 	}
 	return &dynamodb.ScanOutput{}, m.err
+}
+
+func (m *mockDDB) Query(_ context.Context, in *dynamodb.QueryInput, _ ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	m.queryInput = in
+	if m.queryOut != nil {
+		return m.queryOut, m.err
+	}
+	return &dynamodb.QueryOutput{}, m.err
 }
 
 func (m *mockDDB) DeleteItem(_ context.Context, in *dynamodb.DeleteItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.DeleteItemOutput, error) {
@@ -335,3 +345,60 @@ func stringPtr(s string) *string     { return &s }
 func int64Ptr(i int64) *int64        { return &i }
 func intPtr(i int) *int              { return &i }
 func timePtr(t time.Time) *time.Time { return &t }
+
+func TestGetByInstanceID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("found", func(t *testing.T) {
+		mock := &mockDDB{
+			queryOut: &dynamodb.QueryOutput{
+				Items: []map[string]types.AttributeValue{
+					{
+						"runner_id":   &types.AttributeValueMemberS{Value: "r1"},
+						"instance_id": &types.AttributeValueMemberS{Value: "i-aaa"},
+						"status":      &types.AttributeValueMemberS{Value: "pending"},
+					},
+				},
+			},
+		}
+		s := NewStore(mock, "jit-runners-runners")
+		got, err := s.GetByInstanceID(ctx, "i-aaa")
+		if err != nil {
+			t.Fatalf("GetByInstanceID: %v", err)
+		}
+		if got.ID != "r1" {
+			t.Errorf("ID = %q, want r1", got.ID)
+		}
+		if mock.queryInput == nil {
+			t.Fatal("expected Query call")
+		}
+		if got, want := *mock.queryInput.IndexName, "instance_id-index"; got != want {
+			t.Errorf("IndexName = %q, want %q", got, want)
+		}
+		if got, want := *mock.queryInput.TableName, "jit-runners-runners"; got != want {
+			t.Errorf("TableName = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		mock := &mockDDB{queryOut: &dynamodb.QueryOutput{Items: nil}}
+		s := NewStore(mock, "jit-runners-runners")
+		_, err := s.GetByInstanceID(ctx, "i-zzz")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("empty_id_returns_not_found_without_call", func(t *testing.T) {
+		mock := &mockDDB{}
+		s := NewStore(mock, "jit-runners-runners")
+		_, err := s.GetByInstanceID(ctx, "")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+		if mock.queryInput != nil {
+			t.Error("expected no Query call for empty instance ID")
+		}
+	})
+}

--- a/lambda/internal/gcp/firestore/store.go
+++ b/lambda/internal/gcp/firestore/store.go
@@ -86,6 +86,30 @@ func (s *Store) Get(ctx context.Context, id string) (appstate.Runner, error) {
 	return fromDoc(data), nil
 }
 
+// GetByInstanceID looks up a runner by its cloud instance ID using a
+// Firestore field-equality query on the `instance_id` field.
+// Returns state.ErrNotFound if no document matches. Used by the scaledown
+// orphan sweep (issue #74).
+//
+// Firestore's default single-field auto-index handles `==` queries on
+// `instance_id` without an explicit composite-index declaration — no
+// schema change required.
+func (s *Store) GetByInstanceID(ctx context.Context, instanceID string) (appstate.Runner, error) {
+	if instanceID == "" {
+		return appstate.Runner{}, appstate.ErrNotFound
+	}
+	docs, err := s.api.Query(ctx, s.collName, []QueryFilter{
+		{Field: "instance_id", Op: "==", Value: instanceID},
+	})
+	if err != nil {
+		return appstate.Runner{}, fmt.Errorf("gcp/firestore: GetByInstanceID %s: %w", instanceID, err)
+	}
+	if len(docs) == 0 {
+		return appstate.Runner{}, appstate.ErrNotFound
+	}
+	return fromDoc(docs[0]), nil
+}
+
 // List returns runner records matching the filter. StatusEq narrows by status;
 // OlderThan filters client-side records whose LaunchedAt is older than now-OlderThan.
 func (s *Store) List(ctx context.Context, f appstate.Filter) ([]appstate.Runner, error) {

--- a/lambda/internal/gcp/firestore/store_test.go
+++ b/lambda/internal/gcp/firestore/store_test.go
@@ -407,6 +407,64 @@ func TestStore_Update_PartialFields(t *testing.T) {
 	}
 }
 
+func TestGetByInstanceID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("found", func(t *testing.T) {
+		fake := newFakeFirestore()
+		// Seed two docs in the runners collection.
+		_ = fake.Set(ctx, "runners", "r1", map[string]any{
+			"runner_id":   "r1",
+			"instance_id": "i-aaa",
+			"status":      "pending",
+		})
+		_ = fake.Set(ctx, "runners", "r2", map[string]any{
+			"runner_id":   "r2",
+			"instance_id": "i-bbb",
+			"status":      "running",
+		})
+		s := &Store{api: fake, collName: "runners"}
+
+		got, err := s.GetByInstanceID(ctx, "i-bbb")
+		if err != nil {
+			t.Fatalf("GetByInstanceID: %v", err)
+		}
+		if got.ID != "r2" {
+			t.Errorf("ID = %q, want r2", got.ID)
+		}
+		// Confirm the right filter was passed.
+		if len(fake.recordedFilters) != 1 {
+			t.Fatalf("expected 1 filter, got %d", len(fake.recordedFilters))
+		}
+		f := fake.recordedFilters[0]
+		if f.Field != "instance_id" || f.Op != "==" || f.Value != "i-bbb" {
+			t.Errorf("filter = %+v, want {instance_id == i-bbb}", f)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		fake := newFakeFirestore()
+		s := &Store{api: fake, collName: "runners"}
+		_, err := s.GetByInstanceID(ctx, "i-zzz")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("empty_id_returns_not_found_without_call", func(t *testing.T) {
+		fake := newFakeFirestore()
+		s := &Store{api: fake, collName: "runners"}
+		_, err := s.GetByInstanceID(ctx, "")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+		if fake.recordedFilters != nil {
+			t.Errorf("expected no Query call for empty instance_id; recordedFilters = %+v", fake.recordedFilters)
+		}
+	})
+}
+
 // TestStore_Delete_RemovesDoc verifies Delete removes the document.
 func TestStore_Delete_RemovesDoc(t *testing.T) {
 	fake := newFakeFirestore()

--- a/lambda/internal/lifecycle/handler.go
+++ b/lambda/internal/lifecycle/handler.go
@@ -94,5 +94,14 @@ func (h *Handler) HandleSQS(ctx context.Context, body []byte) error {
 			// do not fail the message: DDB is committed; deregister is best-effort.
 		}
 	}
+
+	if msg.Action == "completed" && rec.InstanceID != "" && h.Compute != nil {
+		if err := h.Compute.Terminate(ctx, []string{rec.InstanceID}); err != nil {
+			h.Logger.Printf("lifecycle: terminate %s for runner=%d failed: %v",
+				rec.InstanceID, msg.RunnerID, err)
+			// best-effort: do not fail the message; the scaledown orphan
+			// sweep is the safety net (issue #74 design D1).
+		}
+	}
 	return nil
 }

--- a/lambda/internal/lifecycle/handler_test.go
+++ b/lambda/internal/lifecycle/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -26,6 +27,10 @@ type updateCall struct {
 
 func (f *fakeStore) Get(_ context.Context, _ string) (state.Runner, error) {
 	return f.get, f.getErr
+}
+
+func (f *fakeStore) GetByInstanceID(_ context.Context, _ string) (state.Runner, error) {
+	return state.Runner{}, state.ErrNotFound
 }
 
 func (f *fakeStore) Put(_ context.Context, _ state.Runner) error { return nil }
@@ -94,7 +99,7 @@ func TestHandleSQS_TransitionTable(t *testing.T) {
 				Repository:     "owner/repo",
 			}}
 			gh := &fakeGitHub{}
-			h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+			h := &Handler{Store: store, GitHub: gh, Compute: &fakeCompute{}, Logger: testLogger()}
 
 			body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"` + tc.action + `"}`)
 			if err := h.HandleSQS(context.Background(), body); err != nil {
@@ -131,7 +136,7 @@ func TestHandleSQS_TransitionTable(t *testing.T) {
 func TestHandleSQS_UnknownRecordDrops(t *testing.T) {
 	store := &fakeStore{getErr: state.ErrNotFound}
 	gh := &fakeGitHub{}
-	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+	h := &Handler{Store: store, GitHub: gh, Compute: &fakeCompute{}, Logger: testLogger()}
 
 	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
 	if err := h.HandleSQS(context.Background(), body); err != nil {
@@ -148,7 +153,7 @@ func TestHandleSQS_UnknownRecordDrops(t *testing.T) {
 func TestHandleSQS_DropsWhenRunnerIDZero(t *testing.T) {
 	store := &fakeStore{}
 	gh := &fakeGitHub{}
-	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+	h := &Handler{Store: store, GitHub: gh, Compute: &fakeCompute{}, Logger: testLogger()}
 
 	// runner_id == 0 is the defensive case: GitHub did not include a
 	// runner ID in the workflow_job payload. The handler must drop the
@@ -169,7 +174,7 @@ func TestHandleSQS_DropsWhenRunnerIDZero(t *testing.T) {
 func TestHandleSQS_DeregisterErrorDoesNotFail(t *testing.T) {
 	store := &fakeStore{get: state.Runner{ID: "99", Status: state.StatusRunning, GitHubRunnerID: 99, Repository: "owner/repo"}}
 	gh := &fakeGitHub{err: errors.New("network blip")}
-	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+	h := &Handler{Store: store, GitHub: gh, Compute: &fakeCompute{}, Logger: testLogger()}
 
 	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
 	if err := h.HandleSQS(context.Background(), body); err != nil {
@@ -186,9 +191,123 @@ func TestHandleSQS_DeregisterErrorDoesNotFail(t *testing.T) {
 func TestHandleSQS_BadJSONReturnsError(t *testing.T) {
 	store := &fakeStore{}
 	gh := &fakeGitHub{}
-	h := &Handler{Store: store, GitHub: gh, Logger: testLogger()}
+	h := &Handler{Store: store, GitHub: gh, Compute: &fakeCompute{}, Logger: testLogger()}
 
 	if err := h.HandleSQS(context.Background(), []byte(`{not json`)); err == nil {
 		t.Fatal("expected parse error")
+	}
+}
+
+// fakeCompute records Terminate calls and can be configured to return an error.
+type fakeCompute struct {
+	terminated [][]string
+	err        error
+}
+
+func (f *fakeCompute) Terminate(_ context.Context, ids []string) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.terminated = append(f.terminated, ids)
+	return nil
+}
+
+func TestHandle_TerminatesOnCompleted(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := &fakeStore{
+		get: state.Runner{
+			ID:             "99",
+			InstanceID:     "i-aaa",
+			GitHubRunnerID: 99,
+			Status:         state.StatusRunning,
+		},
+	}
+	gh := &fakeGitHub{}
+	comp := &fakeCompute{}
+
+	h := &Handler{Store: store, GitHub: gh, Compute: comp, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+
+	if len(comp.terminated) != 1 {
+		t.Fatalf("expected 1 Terminate call, got %d", len(comp.terminated))
+	}
+	if got, want := comp.terminated[0], []string{"i-aaa"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("Terminate ids = %v, want %v", got, want)
+	}
+}
+
+func TestHandle_DoesNotTerminateOnInProgress(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := &fakeStore{
+		get: state.Runner{
+			ID:             "99",
+			InstanceID:     "i-aaa",
+			GitHubRunnerID: 99,
+			Status:         state.StatusPending,
+		},
+	}
+	comp := &fakeCompute{}
+	h := &Handler{Store: store, GitHub: &fakeGitHub{}, Compute: comp, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"in_progress"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+
+	if len(comp.terminated) != 0 {
+		t.Errorf("expected 0 Terminate calls on in_progress, got %d", len(comp.terminated))
+	}
+}
+
+func TestHandle_TerminateErrorIsLogged_NoFailure(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := &fakeStore{
+		get: state.Runner{
+			ID:             "99",
+			InstanceID:     "i-aaa",
+			GitHubRunnerID: 99,
+			Status:         state.StatusRunning,
+		},
+	}
+	comp := &fakeCompute{err: errors.New("EC2 throttled")}
+	h := &Handler{Store: store, GitHub: &fakeGitHub{}, Compute: comp, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS: %v (best-effort terminate must not fail the message)", err)
+	}
+}
+
+func TestHandle_NoTerminateWhenInstanceIDEmpty(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := &fakeStore{
+		get: state.Runner{
+			ID:             "99",
+			InstanceID:     "",
+			GitHubRunnerID: 99,
+			Status:         state.StatusRunning,
+		},
+	}
+	comp := &fakeCompute{}
+	h := &Handler{Store: store, GitHub: &fakeGitHub{}, Compute: comp, Logger: testLogger()}
+
+	body := []byte(`{"job_id":1,"repo":"owner/repo","runner_id":99,"action":"completed"}`)
+	if err := h.HandleSQS(ctx, body); err != nil {
+		t.Fatalf("HandleSQS: %v", err)
+	}
+	if len(comp.terminated) != 0 {
+		t.Errorf("expected 0 Terminate calls when InstanceID empty, got %d", len(comp.terminated))
 	}
 }

--- a/lambda/internal/lifecycle/types.go
+++ b/lambda/internal/lifecycle/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
 )
 
@@ -14,17 +15,27 @@ type ghClient interface {
 	DeregisterRunner(ctx context.Context, ownerRepo string, runnerID int64) error
 }
 
-// Handler dispatches lifecycle messages to DDB updates and GitHub deregister calls.
+// computeLauncher is the subset of compute.Launcher the lifecycle handler
+// needs (just Terminate). Defined as a local interface so tests can
+// substitute a fake without satisfying the full Launcher contract.
+type computeLauncher interface {
+	Terminate(ctx context.Context, ids []string) error
+}
+
+// Handler dispatches lifecycle messages to DDB updates, GitHub deregister
+// calls, and (per issue #74) cloud instance termination on the `completed`
+// transition.
 type Handler struct {
-	Store  state.RunnerStore
-	GitHub ghClient
-	Logger *log.Logger
+	Store   state.RunnerStore
+	GitHub  ghClient
+	Compute computeLauncher
+	Logger  *log.Logger
 }
 
 // New constructs a Handler with sane defaults (stdlib logger if nil).
-func New(store state.RunnerStore, gh ghClient, logger *log.Logger) *Handler {
+func New(store state.RunnerStore, gh ghClient, comp compute.Launcher, logger *log.Logger) *Handler {
 	if logger == nil {
 		logger = log.Default()
 	}
-	return &Handler{Store: store, GitHub: gh, Logger: logger}
+	return &Handler{Store: store, GitHub: gh, Compute: comp, Logger: logger}
 }

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -50,6 +51,11 @@ type Cleaner struct {
 	// terminal failed and an ERROR is logged instead of re-publishing.
 	MaxReEnqueueAttempts int
 
+	// OrphanGraceMinutes is the minimum age of a cloud-side instance
+	// before sweepOrphanInstances will consider terminating it. Avoids
+	// races with healthy runner self-terminate. Default 5 min.
+	OrphanGraceMinutes time.Duration
+
 	// Now is injectable for tests; defaults to time.Now if unset.
 	Now func() time.Time
 }
@@ -62,7 +68,7 @@ func NewCleaner(
 	launcher compute.Launcher,
 	gh ghClient,
 	pub scaleupPublisher,
-	staleMinutes, maxAgeMinutes, maxReEnqueueAttempts int,
+	staleMinutes, maxAgeMinutes, maxReEnqueueAttempts, orphanGraceMinutes int,
 ) *Cleaner {
 	if staleMinutes <= 0 {
 		staleMinutes = 10
@@ -73,6 +79,9 @@ func NewCleaner(
 	if maxReEnqueueAttempts < 0 {
 		maxReEnqueueAttempts = 0
 	}
+	if orphanGraceMinutes <= 0 {
+		orphanGraceMinutes = 5
+	}
 	return &Cleaner{
 		Store:                store,
 		Launcher:             launcher,
@@ -81,6 +90,7 @@ func NewCleaner(
 		StaleAfter:           time.Duration(staleMinutes) * time.Minute,
 		MaxAge:               time.Duration(maxAgeMinutes) * time.Minute,
 		MaxReEnqueueAttempts: maxReEnqueueAttempts,
+		OrphanGraceMinutes:   time.Duration(orphanGraceMinutes) * time.Minute,
 		Now:                  time.Now,
 	}
 }
@@ -92,9 +102,10 @@ func NewCleaner(
 // or terminally failed because the budget was exhausted). Errors counts any
 // path where termination or publish failed and we abandoned the record.
 type CleanupResult struct {
-	Stale   int
-	Orphans int
-	Errors  int
+	Stale      int
+	Orphans    int
+	EC2Orphans int // cloud-side orphans (DDB terminal/missing, EC2 alive)
+	Errors     int
 }
 
 // Run executes the cleanup logic:
@@ -119,6 +130,8 @@ func (c *Cleaner) Run(ctx context.Context) (*CleanupResult, error) {
 	}
 	runCutoff := now.Add(-c.MaxAge)
 	c.sweepStaleRunning(ctx, running, runCutoff, now, result)
+
+	c.sweepOrphanInstances(ctx, now, result)
 
 	return result, nil
 }
@@ -251,4 +264,54 @@ func (c *Cleaner) now() time.Time {
 		return c.Now()
 	}
 	return time.Now()
+}
+
+// sweepOrphanInstances lists cloud-side instances tagged managed-by=jit-runners
+// (via the existing Launcher.ListStale primitive — filter semantics match
+// exactly: managed-by tag + state in [running, pending] + age threshold)
+// and terminates any whose RunnerStore row is in a terminal state
+// (StatusCompleted/StatusFailed) or missing entirely.
+//
+// Per issue #74 design D1.2: the architectural fix in the lifecycle handler
+// is the primary path; this sweep is the safety net.
+func (c *Cleaner) sweepOrphanInstances(ctx context.Context, now time.Time, result *CleanupResult) {
+	grace := c.OrphanGraceMinutes
+	if grace <= 0 {
+		grace = 5 * time.Minute
+	}
+	instances, err := c.Launcher.ListStale(ctx, grace)
+	if err != nil {
+		log.Printf("orphan sweep: list instances failed: %v", err)
+		result.Errors++
+		return
+	}
+	for _, inst := range instances {
+		rec, err := c.Store.GetByInstanceID(ctx, inst.ID)
+		switch {
+		case errors.Is(err, state.ErrNotFound):
+			log.Printf("orphan sweep: terminating %s (no DDB row, age=%s)",
+				inst.ID, now.Sub(inst.LaunchedAt))
+			if termErr := c.Launcher.Terminate(ctx, []string{inst.ID}); termErr != nil {
+				log.Printf("orphan sweep: terminate %s failed: %v", inst.ID, termErr)
+				result.Errors++
+				continue
+			}
+			result.EC2Orphans++
+		case err != nil:
+			log.Printf("orphan sweep: lookup %s failed: %v", inst.ID, err)
+			result.Errors++
+		case rec.Status == state.StatusCompleted || rec.Status == state.StatusFailed:
+			log.Printf("orphan sweep: terminating %s (DDB status=%s, age=%s)",
+				inst.ID, rec.Status, now.Sub(inst.LaunchedAt))
+			if termErr := c.Launcher.Terminate(ctx, []string{inst.ID}); termErr != nil {
+				log.Printf("orphan sweep: terminate %s failed: %v", inst.ID, termErr)
+				result.Errors++
+				continue
+			}
+			result.EC2Orphans++
+		default:
+			// Status is StatusPending or StatusRunning — existing
+			// sweeps own these. Leave alone.
+		}
+	}
 }

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/compute"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/queue"
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/state"
+	"github.com/devopsfactory-io/jit-runners/lambda/internal/state/memstore"
 )
 
 // fakeStore is an in-memory state.RunnerStore that captures Update calls so
@@ -28,6 +29,23 @@ type capturedUpdate struct {
 
 func (f *fakeStore) Put(_ context.Context, _ state.Runner) error { return nil }
 func (f *fakeStore) Get(_ context.Context, _ string) (state.Runner, error) {
+	return state.Runner{}, state.ErrNotFound
+}
+
+func (f *fakeStore) GetByInstanceID(_ context.Context, instanceID string) (state.Runner, error) {
+	if instanceID == "" {
+		return state.Runner{}, state.ErrNotFound
+	}
+	for _, r := range f.pending {
+		if r.InstanceID == instanceID {
+			return r, nil
+		}
+	}
+	for _, r := range f.running {
+		if r.InstanceID == instanceID {
+			return r, nil
+		}
+	}
 	return state.Runner{}, state.ErrNotFound
 }
 
@@ -52,11 +70,15 @@ func (f *fakeStore) ListActiveRepos(_ context.Context, _ time.Time) ([]string, e
 }
 
 // fakeLauncher records terminate calls and may inject an error. It also
-// satisfies compute.Launcher (Launch and ListStale return zero values; the
-// cleanup path does not call them).
+// satisfies compute.Launcher (Launch returns zero values; the cleanup path
+// does not call it). ListStale returns listResult/listErr for the orphan
+// sweep tests.
 type fakeLauncher struct {
 	terminated   []string
 	terminateErr error
+
+	listResult []compute.Instance
+	listErr    error
 }
 
 func (f *fakeLauncher) Launch(_ context.Context, _ compute.LaunchSpec) (compute.Instance, error) {
@@ -69,7 +91,10 @@ func (f *fakeLauncher) Terminate(_ context.Context, ids []string) error {
 }
 
 func (f *fakeLauncher) ListStale(_ context.Context, _ time.Duration) ([]compute.Instance, error) {
-	return nil, nil
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listResult, nil
 }
 
 // fakeGitHub records DeregisterRunner calls and may inject an error.
@@ -540,6 +565,147 @@ func TestCleaner_RecordTooFresh_Skipped(t *testing.T) {
 	}
 	if res.Stale != 0 || res.Orphans != 0 || res.Errors != 0 {
 		t.Errorf("result = %+v, want zero", res)
+	}
+}
+
+// orphan-sweep tests ----------------------------------------------------
+
+func TestSweepOrphanInstances_DDBCompleted_Terminates(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-aaa", Status: state.StatusCompleted}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	launcher := &fakeLauncher{
+		listResult: []compute.Instance{{ID: "i-aaa", LaunchedAt: now.Add(-10 * time.Minute)}},
+	}
+	c := &Cleaner{
+		Store:              store,
+		Launcher:           launcher,
+		OrphanGraceMinutes: 5 * time.Minute,
+		Now:                func() time.Time { return now },
+	}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 1 {
+		t.Errorf("EC2Orphans = %d, want 1", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 1 || launcher.terminated[0] != "i-aaa" {
+		t.Errorf("terminated = %v, want [i-aaa]", launcher.terminated)
+	}
+}
+
+func TestSweepOrphanInstances_DDBFailed_Terminates(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-bbb", Status: state.StatusFailed}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	launcher := &fakeLauncher{
+		listResult: []compute.Instance{{ID: "i-bbb", LaunchedAt: now.Add(-10 * time.Minute)}},
+	}
+	c := &Cleaner{Store: store, Launcher: launcher, OrphanGraceMinutes: 5 * time.Minute, Now: func() time.Time { return now }}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 1 {
+		t.Errorf("EC2Orphans = %d, want 1", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 1 || launcher.terminated[0] != "i-bbb" {
+		t.Errorf("terminated = %v, want [i-bbb]", launcher.terminated)
+	}
+}
+
+func TestSweepOrphanInstances_NoDDBRow_Terminates(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New() // empty
+	launcher := &fakeLauncher{
+		listResult: []compute.Instance{{ID: "i-ghost", LaunchedAt: now.Add(-10 * time.Minute)}},
+	}
+	c := &Cleaner{Store: store, Launcher: launcher, OrphanGraceMinutes: 5 * time.Minute, Now: func() time.Time { return now }}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 1 {
+		t.Errorf("EC2Orphans = %d, want 1", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 1 || launcher.terminated[0] != "i-ghost" {
+		t.Errorf("terminated = %v, want [i-ghost]", launcher.terminated)
+	}
+}
+
+func TestSweepOrphanInstances_DDBPending_DoesNotTerminate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-aaa", Status: state.StatusPending}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	launcher := &fakeLauncher{
+		listResult: []compute.Instance{{ID: "i-aaa", LaunchedAt: now.Add(-10 * time.Minute)}},
+	}
+	c := &Cleaner{Store: store, Launcher: launcher, OrphanGraceMinutes: 5 * time.Minute, Now: func() time.Time { return now }}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 0 {
+		t.Errorf("EC2Orphans = %d (pending case), want 0", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 0 {
+		t.Errorf("terminated = %v, want empty (pending sweep owns this)", launcher.terminated)
+	}
+}
+
+func TestSweepOrphanInstances_DDBRunning_DoesNotTerminate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-aaa", Status: state.StatusRunning}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	launcher := &fakeLauncher{
+		listResult: []compute.Instance{{ID: "i-aaa", LaunchedAt: now.Add(-10 * time.Minute)}},
+	}
+	c := &Cleaner{Store: store, Launcher: launcher, OrphanGraceMinutes: 5 * time.Minute, Now: func() time.Time { return now }}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 0 {
+		t.Errorf("EC2Orphans = %d (running case), want 0", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 0 {
+		t.Errorf("terminated = %v, want empty (running sweep owns this)", launcher.terminated)
+	}
+}
+
+func TestSweepOrphanInstances_RecentlyLaunched_DoesNotTerminate(t *testing.T) {
+	// Launcher.ListStale already filters out "younger than threshold"
+	// server-side. This test simulates a ListStale that returned no
+	// instances (everything was within the grace window), and asserts
+	// the sweep is a clean no-op even with a Completed DDB row sitting
+	// around.
+	ctx := context.Background()
+	now := time.Now()
+	store := memstore.New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-aaa", Status: state.StatusCompleted}); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	launcher := &fakeLauncher{
+		// Simulate "ListStale's threshold filtered everything; nothing returned"
+		listResult: nil,
+	}
+	c := &Cleaner{Store: store, Launcher: launcher, OrphanGraceMinutes: 5 * time.Minute, Now: func() time.Time { return now }}
+	result := &CleanupResult{}
+	c.sweepOrphanInstances(ctx, now, result)
+	if result.EC2Orphans != 0 {
+		t.Errorf("EC2Orphans = %d (no instances returned), want 0", result.EC2Orphans)
+	}
+	if len(launcher.terminated) != 0 {
+		t.Errorf("terminated = %v, want empty", launcher.terminated)
 	}
 }
 

--- a/lambda/internal/state/memstore/memstore.go
+++ b/lambda/internal/state/memstore/memstore.go
@@ -52,6 +52,23 @@ func (s *Store) Get(_ context.Context, id string) (state.Runner, error) {
 	return r, nil
 }
 
+// GetByInstanceID returns the runner whose InstanceID matches. Used by the
+// scaledown orphan sweep to cross-reference cloud-side instances against
+// store records.
+func (s *Store) GetByInstanceID(_ context.Context, instanceID string) (state.Runner, error) {
+	if instanceID == "" {
+		return state.Runner{}, state.ErrNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, r := range s.records {
+		if r.InstanceID == instanceID {
+			return r, nil
+		}
+	}
+	return state.Runner{}, state.ErrNotFound
+}
+
 // List returns all records optionally filtered by StatusEq.
 func (s *Store) List(_ context.Context, f state.Filter) ([]state.Runner, error) {
 	s.mu.Lock()

--- a/lambda/internal/state/memstore/memstore_test.go
+++ b/lambda/internal/state/memstore/memstore_test.go
@@ -127,3 +127,40 @@ func TestListActiveRepos(t *testing.T) {
 		}
 	})
 }
+
+func TestGetByInstanceID(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	store := New()
+	if err := store.Put(ctx, state.Runner{ID: "r1", InstanceID: "i-aaa", Status: state.StatusPending}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if err := store.Put(ctx, state.Runner{ID: "r2", InstanceID: "i-bbb", Status: state.StatusRunning}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	t.Run("found", func(t *testing.T) {
+		got, err := store.GetByInstanceID(ctx, "i-bbb")
+		if err != nil {
+			t.Fatalf("GetByInstanceID: %v", err)
+		}
+		if got.ID != "r2" {
+			t.Errorf("ID = %q, want r2", got.ID)
+		}
+	})
+
+	t.Run("not_found", func(t *testing.T) {
+		_, err := store.GetByInstanceID(ctx, "i-zzz")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+	})
+
+	t.Run("empty_id_returns_not_found", func(t *testing.T) {
+		_, err := store.GetByInstanceID(ctx, "")
+		if !errors.Is(err, state.ErrNotFound) {
+			t.Errorf("err = %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/lambda/internal/state/state.go
+++ b/lambda/internal/state/state.go
@@ -58,11 +58,15 @@ type RunnerUpdate struct {
 	LastAttemptAt     *time.Time
 }
 
-// RunnerStore persists Runner records with TTL semantics. Implementations:
-// internal/aws/dynamo (DynamoDB on-demand) and internal/gcp/firestore.
+// RunnerStore defines the cloud-agnostic runner state contract.
 type RunnerStore interface {
 	Put(ctx context.Context, r Runner) error
 	Get(ctx context.Context, id string) (Runner, error)
+	// GetByInstanceID returns the runner whose InstanceID matches the
+	// given cloud instance ID. Returns ErrNotFound if no row matches.
+	// Used by the scaledown orphan sweep to cross-reference cloud-side
+	// EC2/GCE instances against the DDB/Firestore record set.
+	GetByInstanceID(ctx context.Context, instanceID string) (Runner, error)
 	List(ctx context.Context, f Filter) ([]Runner, error)
 	Update(ctx context.Context, id string, fields RunnerUpdate) error
 	Delete(ctx context.Context, id string) error


### PR DESCRIPTION
## Summary

Fixes the orphan-EC2 leak surfaced during the v1.0.0-rc.1 release (issue #74). Two coordinated fixes:

1. **Architectural** — `lifecycle/handler.go` now calls `Compute.Terminate` after transitioning DDB to `StatusCompleted` (best-effort). Closes the primary leak path where the runner agent's self-terminate fails.

2. **Defense in depth** — `runner.Cleaner` adds a third sweep `sweepOrphanInstances` that uses the existing `compute.Launcher.ListStale` to enumerate cloud-side instances tagged `managed-by=jit-runners` and terminates any whose DDB row is in a terminal state (completed/failed) or missing entirely. `OrphanGraceMinutes` (default 5, env-configurable via `ORPHAN_GRACE_MINUTES`) avoids races with healthy self-terminate.

Plus a small defensive Terminate in `scaleup/main.go`'s post-Launch + Update-failed path: previously the function logged and ack'd the message, leaving an orphan with no DDB row. Now it terminates and returns the error so SQS redrives.

### Spec deviation note

Spec D2 proposed adding a new `compute.Launcher.List(filter)` method. During plan-writing it was discovered that `compute.Launcher.ListStale(threshold)` already exists with exactly the right semantics (managed-by tag filter, running/pending state, age threshold). This PR uses `ListStale` directly — no interface change — turning a previously-unused method into the orphan-sweep primitive.

### State store

Adds `RunnerStore.GetByInstanceID` to the cloud-agnostic interface. AWS impl uses a new DDB GSI `instance_id-index` (declared in both CFN template and Terraform); GCP impl uses Firestore's default single-field auto-index on the `instance_id` field (no schema change).

## Refs

- Issue [#74](https://github.com/devopsfactory-io/jit-runners/issues/74)
- Spec: zettelkasten \`Projects/jit-runners/specs/2026-05-04-issue-74-orphan-ec2-cleanup-design.md\` (commit \`05d5bed\`)
- Plan: zettelkasten \`Projects/jit-runners/plans/2026-05-04-issue-74-orphan-ec2-cleanup.md\`

## Test plan

- [x] \`make lambda.test\` passes — 216 tests across 26 packages
- [x] \`make lint\` shows 0 issues
- [x] \`make check-fmt\` clean
- [x] All 6 commits DCO-signed
- [x] CFN + Terraform GSI declarations in sync
- [ ] CI checks (labeler, DCO, Secret Scan, CodeQL, Vulnerability Scan, Scorecard, fmt/vet/test, lint, AMI build, GCE image build) green
- [ ] Visual review on GitHub PR

## Out of scope (separate PRs / follow-ups)

- CloudWatch alarm on DLQ depth — operational PR
- Issue [#49](https://github.com/devopsfactory-io/jit-runners/issues/49) AMI auto-cleanup pre-step — \`ami-build.yml\` workflow PR
- Multi-region GCE image replication to \`eu\`/\`asia\` — separate enhancement

## Post-merge release

1. Cut tag \`v1.0.0-rc.2\` at the merge commit
2. Tag push triggers \`release.yml\` + \`ami-build.yml\` + \`gce-image-build.yml\`
3. Upload zips to \`s3://jit-runners-lambda-s3/v1.0.0-rc.2/\` (rename \`<func>-linux-amd64.zip\` → \`<func>.zip\`)
4. \`update-stack\` swaps Lambda code + DefaultAMI to v1.0.0-rc.2
5. Keep \`v1.0.0-rc.1/\` in S3 as rollback safety; remove \`v1.0.0-rc.4/\` if still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Orphaned EC2 instances are now automatically cleaned up during scaledown operations.
  * Instances that fail to launch are now automatically terminated to prevent resource waste.
  * Enhanced runner tracking by EC2 instance ID for improved instance lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->