### PR TITLE
fix: bump runner version to 2.334.0 (2.332.0 deprecated by GitHub)

### DIFF
--- a/.github/workflows/ami-build.yml
+++ b/.github/workflows/ami-build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       runner_version:
         description: "GitHub Actions runner version"
-        default: "2.332.0"
+        default: "2.334.0"
         required: true
       go_version:
         description: "Go version to pre-install"

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -59,6 +59,15 @@ Parameters:
     Default: t3.large
     Description: Default EC2 instance type for runners when no LabelMappings entry matches.
 
+  RunnerVersion:
+    Type: String
+    Default: 2.334.0
+    Description: >-
+      GitHub Actions runner version the ephemeral runners register with. Keep
+      current — GitHub deprecates old versions and refuses to dispatch jobs to
+      them. If it differs from the pre-baked AMI's version, the runner is
+      downloaded at launch (adds cold-start latency); rebuild the AMI to match.
+
   LabelMappings:
     Type: String
     Default: "[]"
@@ -399,6 +408,7 @@ Resources:
           EC2_DEFAULT_AMI: !Ref DefaultAMI
           DEFAULT_INSTANCE_TYPE: !Ref DefaultInstanceType
           LABEL_MAPPINGS: !Ref LabelMappings
+          RUNNER_VERSION: !Ref RunnerVersion
 
   ScaleUpLogGroup:
     Type: AWS::Logs::LogGroup

--- a/infra/packer/variables.pkr.hcl
+++ b/infra/packer/variables.pkr.hcl
@@ -1,6 +1,6 @@
 variable "runner_version" {
   type        = string
-  default     = "2.332.0"
+  default     = "2.334.0"
   description = "GitHub Actions runner version to pre-install."
 }
 

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -64,6 +64,7 @@ resource "aws_lambda_function" "scaleup" {
       EC2_DEFAULT_AMI                   = var.default_ami
       DEFAULT_INSTANCE_TYPE             = var.default_instance_type
       LABEL_MAPPINGS                    = var.label_mappings
+      RUNNER_VERSION                    = var.runner_version
     }
   }
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -63,6 +63,12 @@ variable "label_mappings" {
   default     = "[]"
 }
 
+variable "runner_version" {
+  description = "GitHub Actions runner version the ephemeral runners register with. Keep current — GitHub deprecates old versions and refuses to dispatch jobs to them. If it differs from the pre-baked AMI's version, the runner is downloaded at launch (adds cold-start latency); rebuild the AMI to match."
+  type        = string
+  default     = "2.334.0"
+}
+
 # --- Lambda ---
 
 variable "webhook_lambda_s3_bucket" {

--- a/lambda/cmd/scaleup/main.go
+++ b/lambda/cmd/scaleup/main.go
@@ -26,7 +26,14 @@ import (
 	"github.com/devopsfactory-io/jit-runners/lambda/internal/webhook"
 )
 
-const defaultRunnerVersion = "2.332.0"
+// defaultRunnerVersion is the GitHub Actions runner version used when the
+// RUNNER_VERSION env var is unset. Keep it current: GitHub periodically
+// deprecates older runner versions and refuses to dispatch jobs to them
+// ("Runner version vX is deprecated and cannot receive messages"), which
+// leaves the ephemeral runner offline and the job stuck queued. Prefer
+// overriding via the RUNNER_VERSION env var (RunnerVersion CFN parameter) so
+// a deprecation can be addressed with a parameter-only deploy.
+const defaultRunnerVersion = "2.334.0"
 
 // queueLister abstracts the listing call for testability. Production code
 // passes *github.Client which satisfies this interface.


### PR DESCRIPTION
## Problem

After the control-plane fixes in #80 deployed (rc.3), ephemeral runners finally launched for vulcan-saas — but **every job stayed queued** and instances self-terminated within seconds. Runner-agent logs (CloudWatch `/jit-runners/userdata`) showed:

```
√ Connected to GitHub
Current runner version: '2.332.0'
An error occured: Runner version v2.332.0 is deprecated and cannot receive messages.
Runner listener exit with terminated error, stop the service, no retry needed.
Exiting runner... JIT_NO_JOB_PICKUP runner_id=84 runtime=4s
```

GitHub deprecated runner **v2.332.0** — it accepts the connection but refuses to dispatch jobs, so the runner exits, the instance self-terminates, and the job never runs (leaving an `offline` zombie runner). Both the hardcoded `defaultRunnerVersion` and the pre-baked AMI shipped 2.332.0.

## Fix

- `scaleup`: `defaultRunnerVersion` 2.332.0 → **2.334.0** (latest; 2.333.x also superseded).
- **Operability:** add a `RunnerVersion` CFN parameter + TF `runner_version` variable wired to the scaleup `RUNNER_VERSION` env var — so the *next* GitHub deprecation is a parameter-only deploy, not a code release.
- Bump Packer/AMI defaults (`variables.pkr.hcl`, `ami-build.yml`) to 2.334.0.

Until the AMI is rebuilt, the userdata downloads 2.334.0 at launch (it differs from the AMI's baked 2.332.0) — adds ~30s cold start but works. Rebuilding the AMI (`ami-build.yml`, runner_version=2.334.0) + updating `DefaultAMI` removes that overhead.

## Validation

- `go test ./cmd/scaleup/...` 15 pass, `go vet` clean.
- `tofu fmt -check` clean (changed files); `cloudformation validate-template` ok (RunnerVersion param present, default 2.334.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner version from 2.332.0 to 2.334.0 across all infrastructure components and deployment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devopsfactory-io/jit-runners/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->