### PR TITLE
fix(ci): free us-east-1 public-AMI slot before distribute (closes #86)

### DIFF
--- a/.github/workflows/ami-build.yml
+++ b/.github/workflows/ami-build.yml
@@ -172,6 +172,18 @@ jobs:
             echo "Use this AMI as \`DefaultAMI\` in CloudFormation or \`default_ami\` in Terraform." >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Pre-distribute free-slot guard (us-east-1)
+        if: github.event_name != 'pull_request' && (inputs.distribute == true || inputs.distribute == '')
+        run: |
+          # Free a public-AMI slot in us-east-1 BEFORE the copy, so the publish below
+          # cannot hit the 5-public-AMI quota (the post-build prune only runs afterward).
+          # No-op unless us-east-1 is at/near the ceiling; never drops the 2 newest. (#86)
+          ./infra/scripts/ami-prune.sh \
+            --regions us-east-1 \
+            --keep-latest 2 \
+            --ensure-free 1 \
+            --apply
+
       - name: Distribute source AMI to us-east-1
         if: github.event_name != 'pull_request' && (inputs.distribute == true || inputs.distribute == '')
         working-directory: infra/packer


### PR DESCRIPTION
## Problem (#86)
On the **v1.0.0-rc.5** release, the `Distribute source AMI to us-east-1` step failed to publish with `ResourceLimitExceeded` (5-public-AMI quota) because us-east-1 still held 5 AMIs from the former 9-region era. The pre-build `--ensure-free` guard only frees **us-east-2**, and the us-east-1 prune runs in the *post-build* `prune` job — i.e. after the publish. The copy was left private until I published it manually.

## Fix
Add a `Pre-distribute free-slot guard (us-east-1)` step immediately **before** the copy/publish step, mirroring the us-east-2 guard:

```yaml
./infra/scripts/ami-prune.sh --regions us-east-1 --keep-latest 2 --ensure-free 1 --apply
```

- **No-op in steady state** (us-east-1 sits at ≤2 public AMIs after each prune; `--ensure-free 1` only acts at/near the quota ceiling).
- **Never deregisters the 2 newest** public AMIs.
- Runs from repo root (no `working-directory`), using the same OIDC role; the role already has the required perms in us-east-1 (`AmiPrune` inline policy, `Resource:*`).

## Validation
`actionlint` clean (no new findings). Step order confirmed: us-east-2 guard → **us-east-1 guard** → distribute → post-build prune. The underlying `ami-prune.sh --ensure-free` path is already covered by the script's unit tests.

Closes #86. Related: #83, #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build and distribution workflow to better manage resource allocation during AMI deployment, optimizing slot management before distribution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->