### PR TITLE
fix(infra): replace unsupported t2.* spot types with t3a/t3 in LabelMappings

### DIFF
--- a/docs/getting-started-aws.md
+++ b/docs/getting-started-aws.md
@@ -166,11 +166,13 @@ Add these to `--parameter-overrides` if needed:
 
 Both the CloudFormation template and the Terraform module ship with the following six-class default. Labels without an `instance_types` list launch a single fixed type; labels with a list try each candidate in order on spot (first-success-wins) and fall back to on-demand only if every candidate is unavailable.
 
+> **Note:** avoid `t2.*` types — EC2 rejects them for new spot launches (`InvalidParameterValue: 't2.nano' is an unsupported instance type`), which strands every job on that label in a queued state. The small tiers default to `t3a`/`t3` for this reason (2026-07-03).
+
 | Label | Primary type | Spot candidate list |
 |-------|-------------|---------------------|
-| nano | t2.nano | _(single type)_ |
-| micro | t2.micro | _(single type)_ |
-| small | t2.small | _(single type)_ |
+| nano | t3a.nano | t3a.nano, t3.nano, t3a.micro, t3.micro |
+| micro | t3a.micro | t3a.micro, t3.micro, t3a.small, t3.small |
+| small | t3a.small | t3a.small, t3.small, t3a.medium, t3.medium |
 | medium | t3.medium | t3.medium, t3a.medium, m6i.large, m5.large |
 | large | c6i.xlarge | c6i.xlarge, c5.xlarge, c5a.xlarge, m6i.xlarge |
 | release | m5.xlarge | m5.xlarge, m5a.xlarge, m6i.xlarge, m6a.xlarge |

--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -70,7 +70,7 @@ Parameters:
 
   LabelMappings:
     Type: String
-    Default: '[{"label":"nano","instance_type":"t2.nano"},{"label":"micro","instance_type":"t2.micro"},{"label":"small","instance_type":"t2.small"},{"label":"medium","instance_type":"t3.medium","instance_types":["t3.medium","t3a.medium","m6i.large","m5.large"]},{"label":"large","instance_type":"c6i.xlarge","instance_types":["c6i.xlarge","c5.xlarge","c5a.xlarge","m6i.xlarge"]},{"label":"release","instance_type":"m5.xlarge","instance_types":["m5.xlarge","m5a.xlarge","m6i.xlarge","m6a.xlarge"]}]'
+    Default: '[{"label":"nano","instance_type":"t3a.nano","instance_types":["t3a.nano","t3.nano","t3a.micro","t3.micro"]},{"label":"micro","instance_type":"t3a.micro","instance_types":["t3a.micro","t3.micro","t3a.small","t3.small"]},{"label":"small","instance_type":"t3a.small","instance_types":["t3a.small","t3.small","t3a.medium","t3.medium"]},{"label":"medium","instance_type":"t3.medium","instance_types":["t3.medium","t3a.medium","m6i.large","m5.large"]},{"label":"large","instance_type":"c6i.xlarge","instance_types":["c6i.xlarge","c5.xlarge","c5a.xlarge","m6i.xlarge"]},{"label":"release","instance_type":"m5.xlarge","instance_types":["m5.xlarge","m5a.xlarge","m6i.xlarge","m6a.xlarge"]}]'
     Description: "(Optional) JSON array of label-to-instance-type mappings."
 
   StaleThresholdMinutes:

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "default_instance_type" {
 variable "label_mappings" {
   description = "JSON-encoded label-to-instance-type mappings"
   type        = string
-  default     = "[{\"label\":\"nano\",\"instance_type\":\"t2.nano\"},{\"label\":\"micro\",\"instance_type\":\"t2.micro\"},{\"label\":\"small\",\"instance_type\":\"t2.small\"},{\"label\":\"medium\",\"instance_type\":\"t3.medium\",\"instance_types\":[\"t3.medium\",\"t3a.medium\",\"m6i.large\",\"m5.large\"]},{\"label\":\"large\",\"instance_type\":\"c6i.xlarge\",\"instance_types\":[\"c6i.xlarge\",\"c5.xlarge\",\"c5a.xlarge\",\"m6i.xlarge\"]},{\"label\":\"release\",\"instance_type\":\"m5.xlarge\",\"instance_types\":[\"m5.xlarge\",\"m5a.xlarge\",\"m6i.xlarge\",\"m6a.xlarge\"]}]"
+  default     = "[{\"label\":\"nano\",\"instance_type\":\"t3a.nano\",\"instance_types\":[\"t3a.nano\",\"t3.nano\",\"t3a.micro\",\"t3.micro\"]},{\"label\":\"micro\",\"instance_type\":\"t3a.micro\",\"instance_types\":[\"t3a.micro\",\"t3.micro\",\"t3a.small\",\"t3.small\"]},{\"label\":\"small\",\"instance_type\":\"t3a.small\",\"instance_types\":[\"t3a.small\",\"t3.small\",\"t3a.medium\",\"t3.medium\"]},{\"label\":\"medium\",\"instance_type\":\"t3.medium\",\"instance_types\":[\"t3.medium\",\"t3a.medium\",\"m6i.large\",\"m5.large\"]},{\"label\":\"large\",\"instance_type\":\"c6i.xlarge\",\"instance_types\":[\"c6i.xlarge\",\"c5.xlarge\",\"c5a.xlarge\",\"m6i.xlarge\"]},{\"label\":\"release\",\"instance_type\":\"m5.xlarge\",\"instance_types\":[\"m5.xlarge\",\"m5a.xlarge\",\"m6i.xlarge\",\"m6a.xlarge\"]}]"
 }
 
 variable "runner_version" {


### PR DESCRIPTION
EC2 rejects t2.* for new spot launches (InvalidParameterValue:
't2.nano' is an unsupported instance type), so every job labeled
nano/micro/small queued forever with zero runners launching — took
down all self-hosted CI org-wide on 2026-07-03. nano/micro/small now
default to t3a primaries with t3a/t3 spot candidate lists, matching
the diversification pattern of the medium/large/release tiers.

Prod jit-runners stack already hotfixed via the same LabelMappings
parameter value; this aligns the shipped defaults.

Signed-off-by: Kaio Fellipe <kaio6fellipe@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated small-instance recommendations to avoid Spot launch types that are no longer accepted, reducing the chance of jobs staying queued.
  * Improved default instance selection for smaller tiers by adding fallback options instead of relying on a single choice.

* **Documentation**
  * Refreshed getting-started guidance to reflect the latest supported instance families and Spot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->