### PR TITLE
fix: stop the orphan sweep killing live runners + grant lifecycle ec2:TerminateInstances

### DIFF
--- a/infra/cloudformation/template.yaml
+++ b/infra/cloudformation/template.yaml
@@ -537,6 +537,16 @@ Resources:
                   - dynamodb:GetItem
                   - dynamodb:UpdateItem
                 Resource: !GetAtt RunnersTable.Arn
+              # The lifecycle handler terminates the runner's instance on the
+              # 'completed' transition. Without this the call 403s on every
+              # completed job and cleanup falls through to scaledown's orphan
+              # sweep, leaving instances billing until MaxRunnerAgeMinutes.
+              # Mirrors the scaledown role's EC2 grant.
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ec2:TerminateInstances
+                Resource: "*"
               - Effect: Allow
                 Action: secretsmanager:GetSecretValue
                 Resource: !Ref PrivateKeySecretArn

--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -428,6 +428,19 @@ resource "aws_iam_role_policy" "lifecycle_lambda" {
         ]
         Resource = aws_dynamodb_table.runners.arn
       },
+      # The lifecycle handler terminates the runner's instance on the
+      # 'completed' transition. Without this the call 403s on every completed
+      # job and cleanup falls through to scaledown's orphan sweep, leaving
+      # instances billing until max_runner_age_minutes. Mirrors the scaledown
+      # role's EC2 grant.
+      {
+        Effect = "Allow"
+        Action = [
+          "ec2:DescribeInstances",
+          "ec2:TerminateInstances",
+        ]
+        Resource = "*"
+      },
       {
         Effect   = "Allow"
         Action   = ["secretsmanager:GetSecretValue"]

--- a/lambda/internal/runner/cleanup.go
+++ b/lambda/internal/runner/cleanup.go
@@ -287,10 +287,21 @@ func (c *Cleaner) sweepOrphanInstances(ctx context.Context, now time.Time, resul
 	}
 	for _, inst := range instances {
 		rec, err := c.Store.GetByInstanceID(ctx, inst.ID)
+		// The instance-ID index only contains rows that already carry an
+		// InstanceID, which scaleup writes *after* the launch returns. A
+		// row whose post-launch bind never landed (throttled or timed-out
+		// update) is therefore absent from the index even though the
+		// runner is alive and may already have claimed a job. Terminating
+		// on that miss kills running jobs, so resolve the row by primary
+		// key through the instance's jit-runners-id tag before believing
+		// the instance is untracked.
+		if errors.Is(err, state.ErrNotFound) && inst.RunnerID != "" {
+			rec, err = c.Store.Get(ctx, inst.RunnerID)
+		}
 		switch {
 		case errors.Is(err, state.ErrNotFound):
-			log.Printf("orphan sweep: terminating %s (no DDB row, age=%s)",
-				inst.ID, now.Sub(inst.LaunchedAt))
+			log.Printf("orphan sweep: terminating %s (no record by instance-id or tag %q, age=%s)",
+				inst.ID, inst.RunnerID, now.Sub(inst.LaunchedAt))
 			if termErr := c.Launcher.Terminate(ctx, []string{inst.ID}); termErr != nil {
 				log.Printf("orphan sweep: terminate %s failed: %v", inst.ID, termErr)
 				result.Errors++

--- a/lambda/internal/runner/cleanup_test.go
+++ b/lambda/internal/runner/cleanup_test.go
@@ -713,3 +713,105 @@ func TestSweepOrphanInstances_RecentlyLaunched_DoesNotTerminate(t *testing.T) {
 // scaleupPublisher interface remains compatible with state.RunnerUpdate
 // usage in cleanup.go. It exists only to surface signature drift early.
 var _ = state.RunnerUpdate{}
+
+// TestSweepOrphanInstances_TagFallback covers the instance-ID index blind
+// spot: scaleup writes the record before launching and binds InstanceID only
+// after RunInstances returns, so a throttled or timed-out bind leaves a live
+// runner with a record that the index cannot see. The sweep must resolve such
+// rows by primary key through the instance's jit-runners-id tag instead of
+// terminating a runner that may already be executing a job.
+func TestSweepOrphanInstances_TagFallback(t *testing.T) {
+	now := time.Now()
+	stale := now.Add(-10 * time.Minute)
+
+	tests := []struct {
+		name          string
+		seed          *state.Runner // record to Put, nil for none
+		instRunnerID  string        // jit-runners-id tag on the instance
+		wantTerminate bool
+	}{
+		{
+			name:          "unbound record pending, tag resolves it",
+			seed:          &state.Runner{ID: "r-1", Status: state.StatusPending},
+			instRunnerID:  "r-1",
+			wantTerminate: false,
+		},
+		{
+			name:          "unbound record running, tag resolves it",
+			seed:          &state.Runner{ID: "r-2", Status: state.StatusRunning},
+			instRunnerID:  "r-2",
+			wantTerminate: false,
+		},
+		{
+			name:          "bound record still resolves via index",
+			seed:          &state.Runner{ID: "r-3", InstanceID: "i-live", Status: state.StatusRunning},
+			instRunnerID:  "r-3",
+			wantTerminate: false,
+		},
+		{
+			name:          "unbound record completed is terminal",
+			seed:          &state.Runner{ID: "r-4", Status: state.StatusCompleted},
+			instRunnerID:  "r-4",
+			wantTerminate: true,
+		},
+		{
+			name:          "unbound record failed is terminal",
+			seed:          &state.Runner{ID: "r-5", Status: state.StatusFailed},
+			instRunnerID:  "r-5",
+			wantTerminate: true,
+		},
+		{
+			name:          "tag present but no record at that key",
+			seed:          nil,
+			instRunnerID:  "r-absent",
+			wantTerminate: true,
+		},
+		{
+			name:          "no tag and no record stays terminable",
+			seed:          nil,
+			instRunnerID:  "",
+			wantTerminate: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := memstore.New()
+			if tt.seed != nil {
+				if err := store.Put(ctx, *tt.seed); err != nil {
+					t.Fatalf("seed Put: %v", err)
+				}
+			}
+			launcher := &fakeLauncher{
+				listResult: []compute.Instance{
+					{ID: "i-live", LaunchedAt: stale, RunnerID: tt.instRunnerID},
+				},
+			}
+			c := &Cleaner{
+				Store:              store,
+				Launcher:           launcher,
+				OrphanGraceMinutes: 5 * time.Minute,
+				Now:                func() time.Time { return now },
+			}
+			result := &CleanupResult{}
+			c.sweepOrphanInstances(ctx, now, result)
+
+			terminated := len(launcher.terminated) > 0
+			if terminated != tt.wantTerminate {
+				t.Errorf("terminated = %v (%v), want %v",
+					terminated, launcher.terminated, tt.wantTerminate)
+			}
+			wantOrphans := 0
+			if tt.wantTerminate {
+				wantOrphans = 1
+			}
+			if result.EC2Orphans != wantOrphans {
+				t.Errorf("EC2Orphans = %d, want %d", result.EC2Orphans, wantOrphans)
+			}
+			if result.Errors != 0 {
+				t.Errorf("Errors = %d, want 0", result.Errors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two independent fleet bugs surfaced while recovering vulcan-saas CI from the runner-deprecation outage (#98). Both are durable source fixes.

---

## Fix 1 — the orphan sweep terminates live runners (the severe one)

The sweep resolves instances via `Store.GetByInstanceID`, backed by the **instance-id secondary index**. That index only contains rows that already carry an `InstanceID` — and scaleup writes the record *before* launching, binding `InstanceID` only after `RunInstances` returns. When that post-launch bind does not land, the row exists **at its primary key** but is invisible to the index.

The sweep read that miss as "no DDB row" and killed the instance:

```
cleanup.go:292: orphan sweep: terminating i-0f063963538d70eda (no DDB row, age=6m29.656811753s)
```

That instance had claimed a vulcan-saas `go` job **24 seconds after launch** and was killed **2m46s into the test step**. Any job longer than the 5-minute orphan grace is exposed, so the 16-minute `go` job was killed on every attempt.

**Why the bind failed:** during the backlog drain the account hit the EC2 `RunInstances` rate limit and the spot cap, and the DynamoDB update went with it:

```
main.go:268: mark runner failed for runner=36659 job=95254845060:
  dynamo: Update 36659: operation error DynamoDB: UpdateItem, context deadline exceeded
```

**The fix:** resolve the record by primary key through the instance's `jit-runners-id` tag before concluding it is untracked. Both launchers already set that tag and already read it back into `compute.Instance.RunnerID` — and that value *is* the store's partition key. No new tag, API call, or schema change; a four-line change. A genuinely untracked instance still terminates, and a terminal record still terminates.

Cloud parity confirmed: the GCE launcher sets the same `jit-runners-id` label and reads it back in `ListStale`, and `sanitizeLabel` passes digits through unchanged, so numeric runner IDs round-trip exactly on GCP too.

I also reworded the log line to name which lookups missed — "no DDB row" was itself misleading, because the row was there.

### Tests

`TestSweepOrphanInstances_TagFallback`, table-driven, 7 cases. **Verified it fails without the fix** — the two live-job cases flip:

```
--- FAIL: .../unbound_record_pending,_tag_resolves_it
        terminated = true ([i-live]), want false
--- FAIL: .../unbound_record_running,_tag_resolves_it
        terminated = true ([i-live]), want false
```

The terminal and genuinely-untracked cases pass either way, which is correct — they should still terminate.

---

## Fix 2 — lifecycle role cannot terminate instances

`internal/lifecycle/handler.go` terminates the runner's instance on the `completed` transition, but **neither IaC path grants the lifecycle role any `ec2:*` action**:

```
User: arn:aws:sts::767000629676:assumed-role/jit-runners-lifecycle-lambda/jit-runners-lifecycle
is not authorized to perform: ec2:TerminateInstances ... because no identity-based policy
allows the ec2:TerminateInstances action
```

A **source bug, not drift** — the deployed role matches the template exactly. Fixed in **both** CloudFormation and Terraform (Terraform had the identical gap), mirroring the scaledown role which already carries exactly this pair.

The call is best-effort and runs *after* the DDB transition commits, so it never fails a message. What it costs is prompt teardown: instances survive until the orphan sweep reaps them, billing and holding their registration in the meantime.

`Resource: "*"` matches the existing scaledown grant. EC2 terminate cannot be scoped by ARN without tag conditions, which neither role uses today; scoping both roles by the `jit-runners-id` tag is a reasonable follow-up, deliberately out of scope here.

---

## On "count only `online` runners as supply" — not implementable as described

This was requested, and it should **not** be built, because the premise does not hold. Supply is **not** computed from GitHub runner registrations:

```go
// scaleup shouldLaunch
pending, err := store.List(ctx, state.Filter{StatusEq: state.StatusPending})
```

`internal/github/client.go` exposes exactly five methods — `GenerateJITConfig`, `DeregisterRunner`, `ListQueuedWorkflowJobs`, `listQueuedRuns`, `listJobsForRun`. **None lists runners.** The rebalancer says so in its own doc comment: "computes per-label-set demand from GitHub and supply from DDB pending runners."

So stale registrations never suppressed a launch, and filtering them would mean *adding* a runners API call that does not exist today — extra latency and rate-limit pressure on every scaleup, for no behavioral gain.

The real analogue of that concern is **stale `pending` rows** inflating supply, which is exactly what Fix 1 addresses at the root: rows went stale precisely because the bind failed. Registrations are a symptom, not an input. (Empirically: after a manual purge to 0, the count was back to 54 within four minutes — these are live JIT mints that read `offline` until their agent connects, not ghosts.)

---

## Verification

- `go build ./...`, `go vet ./...` clean; `gofmt -s -l` clean.
- `go test ./...` — **243 passed across 26 packages** (was 235; +8 from the new table).
- CloudFormation template parses; the lifecycle policy now carries 4 statements including the EC2 pair.
- `tofu fmt -check lambda.tf` clean. (`api_gateway.tf` reports diffs but is already unformatted on `main` — pre-existing, untouched.)

## Deploying this

The two fixes take different paths:

- **Fix 2 is template-only** — an `update-stack` with the new template applies it; no new artifact.
- **Fix 1 is Lambda code** — it needs a release and the `ScaleDownLambdaS3Key` pointed at the new `scaledown.zip`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned runner instances by using runner ID information when direct instance lookup is unavailable.
  * Prevented active or pending runners from being terminated unnecessarily.
  * Ensured completed, failed, missing, and untagged instances are handled correctly during cleanup.
* **Reliability**
  * Enabled lifecycle cleanup to inspect and terminate eligible compute instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->